### PR TITLE
Upgrade package:http2 dependency.

### DIFF
--- a/example/route_guide/pubspec.yaml
+++ b/example/route_guide/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   grpc:
     path: ../../
   protobuf: ^0.5.4
-  http2: ^0.1.1+2
+  http2: ^0.1.2
 
 dev_dependencies:
   test: ^0.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   async: ^1.13.3
   meta: ^1.0.5
-  http2: ^0.1.1+2
+  http2: ^0.1.2
 
 dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
Picks up fix for sending endStream bit on the requested frame, instead
of on an empty data frame following it.

Needed for interoperability with the Go gRPC client, since it otherwise
failed to recognize the trailer frame sent from the server.

Fixes #13.