### PR TITLE
Fix analyze task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ matrix:
   # Wish we could exclude `example` in `analysis_options.yaml` but it seems
   # blocked by https://github.com/dart-lang/sdk/issues/26212
   - dart: dev
-    dart_task: dartanalyzer lib test
+    script:
+    - dartanalyzer lib test
+    - for example in example/*; do (cd $example; echo [Analyzing $example]; pub get; dartanalyzer .); done
+
 
 # Only building master means that we don't run two builds for each pull request.
 branches:


### PR DESCRIPTION
Using `dart_task: dartanalyzer lib test` didn't actually work - looks like Travis just runs the tests instead of the analyzer.

So let's try a custom script instead.