### PR TITLE
Preparation for RPC multiplexing

### DIFF
--- a/example/metadata/lib/src/client.dart
+++ b/example/metadata/lib/src/client.dart
@@ -22,10 +22,13 @@ class Client {
     await runAddOneCancel();
     await runFibonacciCancel();
     await runFibonacciTimeout();
-    await channel.close();
+    await channel.shutdown();
   }
 
-  // Run the echo demo. ...
+  /// Run the echo demo.
+  ///
+  /// Send custom metadata with a RPC, and print out the received response and
+  /// metadata.
   Future<Null> runEcho() async {
     final request = new Record()..value = 'Kaj';
     final call = stub.echo(request,
@@ -40,7 +43,11 @@ class Client {
     print('Echo response: ${response.value}');
   }
 
-  // Run the echo with delay cancel demo. ...
+  /// Run the echo with delay cancel demo.
+  ///
+  /// Same as the echo demo, but demonstrating per-client custom metadata, as
+  /// well as a per-call metadata. The server will delay the response for the
+  /// requested duration, during which the client will cancel the RPC.
   Future<Null> runEchoDelayCancel() async {
     final stubWithCustomOptions = new MetadataClient(channel,
         options: new CallOptions(metadata: {'peer': 'Verner'}));
@@ -63,7 +70,10 @@ class Client {
     }
   }
 
-  // Run the addOne cancel demo.
+  /// Run the addOne cancel demo.
+  ///
+  /// Makes a bi-directional RPC, sends 4 requests, and cancels the RPC after
+  /// receiving 3 responses.
   Future<Null> runAddOneCancel() async {
     final numbers = new StreamController<int>();
     final call =
@@ -74,7 +84,7 @@ class Client {
       if (number.value == 3) {
         receivedThree.complete(true);
       }
-    });
+    }, onError: (e) => print('Caught: $e'));
     numbers.add(1);
     numbers.add(2);
     numbers.add(3);
@@ -84,23 +94,43 @@ class Client {
     await Future.wait([sub.cancel(), numbers.close()]);
   }
 
+  /// Run the Fibonacci demo.
+  ///
   /// Call an RPC that returns a stream of Fibonacci numbers. Cancel the call
   /// after receiving more than 5 responses.
   Future<Null> runFibonacciCancel() async {
     final call = stub.fibonacci(new Empty());
     int count = 0;
-    await for (var number in call) {
-      count++;
-      print('Received ${number.value} (count=$count)');
-      if (count > 5) {
-        await call.cancel();
+    try {
+      await for (var number in call) {
+        count++;
+        print('Received ${number.value} (count=$count)');
+        if (count > 5) {
+          await call.cancel();
+        }
       }
+    } on GrpcError catch (e) {
+      print('Caught: $e');
     }
     print('Final count: $count');
   }
 
-  // Run the timeout demo. ...
+  /// Run the timeout demo.
+  ///
+  /// Call an RPC that returns a stream of Fibonacci numbers, and specify a RPC
+  /// timeout of 2 seconds.
   Future<Null> runFibonacciTimeout() async {
-    // TODO(jakobr): Implement timeouts.
+    final call = stub.fibonacci(new Empty(),
+        options: new CallOptions(timeout: new Duration(seconds: 2)));
+    int count = 0;
+    try {
+      await for (var number in call) {
+        count++;
+        print('Received ${number.value} (count=$count)');
+      }
+    } on GrpcError catch (e) {
+      print('Caught: $e');
+    }
+    print('Final count: $count');
   }
 }

--- a/example/metadata/lib/src/client.dart
+++ b/example/metadata/lib/src/client.dart
@@ -117,7 +117,7 @@ class Client {
 
   /// Run the timeout demo.
   ///
-  /// Call an RPC that returns a stream of Fibonacci numbers, and specify a RPC
+  /// Call an RPC that returns a stream of Fibonacci numbers, and specify an RPC
   /// timeout of 2 seconds.
   Future<Null> runFibonacciTimeout() async {
     final call = stub.fibonacci(new Empty(),

--- a/example/metadata/lib/src/generated/metadata.pb.dart
+++ b/example/metadata/lib/src/generated/metadata.pb.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc_metadata;
 
 // ignore: UNUSED_SHOWN_NAME

--- a/example/metadata/lib/src/generated/metadata.pbgrpc.dart
+++ b/example/metadata/lib/src/generated/metadata.pbgrpc.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc_metadata_pbgrpc;
 
 import 'dart:async';
@@ -30,24 +29,19 @@ class MetadataClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<Record> echo(Record request, {CallOptions options}) {
-    final call = $createCall(_$echo, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$echo, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<Number> addOne(Stream<Number> request, {CallOptions options}) {
-    final call = $createCall(_$addOne, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$addOne, request, options: options);
     return new ResponseStream(call);
   }
 
   ResponseStream<Number> fibonacci(Empty request, {CallOptions options}) {
-    final call = $createCall(_$fibonacci, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$fibonacci, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseStream(call);
   }
 }

--- a/example/route_guide/lib/src/client.dart
+++ b/example/route_guide/lib/src/client.dart
@@ -24,7 +24,7 @@ class Client {
     await runListFeatures();
     await runRecordRoute();
     await runRouteChat();
-    await channel.close();
+    await channel.shutdown();
   }
 
   void printFeature(Feature feature) {

--- a/example/route_guide/lib/src/generated/route_guide.pbgrpc.dart
+++ b/example/route_guide/lib/src/generated/route_guide.pbgrpc.dart
@@ -34,33 +34,27 @@ class RouteGuideClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<Feature> getFeature(Point request, {CallOptions options}) {
-    final call = $createCall(_$getFeature, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$getFeature, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<Feature> listFeatures(Rectangle request,
       {CallOptions options}) {
-    final call = $createCall(_$listFeatures, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$listFeatures, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseStream(call);
   }
 
   ResponseFuture<RouteSummary> recordRoute(Stream<Point> request,
       {CallOptions options}) {
-    final call = $createCall(_$recordRoute, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$recordRoute, request, options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<RouteNote> routeChat(Stream<RouteNote> request,
       {CallOptions options}) {
-    final call = $createCall(_$routeChat, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$routeChat, request, options: options);
     return new ResponseStream(call);
   }
 }

--- a/interop/bin/server.dart
+++ b/interop/bin/server.dart
@@ -84,8 +84,11 @@ class TestService extends TestServiceBase {
       throw new GrpcError.custom(
           request.responseStatus.code, request.responseStatus.message);
     }
-    return new StreamingOutputCallResponse()
-      ..payload = _payloadForRequest(request.responseParameters[0]);
+    final response = new StreamingOutputCallResponse();
+    if (request.responseParameters.isNotEmpty) {
+      response.payload = _payloadForRequest(request.responseParameters[0]);
+    }
+    return response;
   }
 
   @override

--- a/interop/lib/src/generated/empty.pb.dart
+++ b/interop/lib/src/generated/empty.pb.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc.testing_empty;
 
 // ignore: UNUSED_SHOWN_NAME

--- a/interop/lib/src/generated/messages.pb.dart
+++ b/interop/lib/src/generated/messages.pb.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc.testing_messages;
 
 // ignore: UNUSED_SHOWN_NAME

--- a/interop/lib/src/generated/messages.pbenum.dart
+++ b/interop/lib/src/generated/messages.pbenum.dart
@@ -1,11 +1,10 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc.testing_messages_pbenum;
 
-// ignore: UNUSED_SHOWN_NAME
+// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
 import 'dart:core' show int, dynamic, String, List, Map;
 import 'package:protobuf/protobuf.dart';
 

--- a/interop/lib/src/generated/test.pb.dart
+++ b/interop/lib/src/generated/test.pb.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc.testing_test;
 
 // ignore: UNUSED_SHOWN_NAME

--- a/interop/lib/src/generated/test.pbgrpc.dart
+++ b/interop/lib/src/generated/test.pbgrpc.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library grpc.testing_test_pbgrpc;
 
 import 'dart:async';
@@ -60,71 +59,61 @@ class TestServiceClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<Empty> emptyCall(Empty request, {CallOptions options}) {
-    final call = $createCall(_$emptyCall, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$emptyCall, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseFuture<SimpleResponse> unaryCall(SimpleRequest request,
       {CallOptions options}) {
-    final call = $createCall(_$unaryCall, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$unaryCall, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseFuture<SimpleResponse> cacheableUnaryCall(SimpleRequest request,
       {CallOptions options}) {
-    final call = $createCall(_$cacheableUnaryCall, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(
+        _$cacheableUnaryCall, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<StreamingOutputCallResponse> streamingOutputCall(
       StreamingOutputCallRequest request,
       {CallOptions options}) {
-    final call = $createCall(_$streamingOutputCall, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(
+        _$streamingOutputCall, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseStream(call);
   }
 
   ResponseFuture<StreamingInputCallResponse> streamingInputCall(
       Stream<StreamingInputCallRequest> request,
       {CallOptions options}) {
-    final call = $createCall(_$streamingInputCall, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$streamingInputCall, request, options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<StreamingOutputCallResponse> fullDuplexCall(
       Stream<StreamingOutputCallRequest> request,
       {CallOptions options}) {
-    final call = $createCall(_$fullDuplexCall, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$fullDuplexCall, request, options: options);
     return new ResponseStream(call);
   }
 
   ResponseStream<StreamingOutputCallResponse> halfDuplexCall(
       Stream<StreamingOutputCallRequest> request,
       {CallOptions options}) {
-    final call = $createCall(_$halfDuplexCall, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$halfDuplexCall, request, options: options);
     return new ResponseStream(call);
   }
 
   ResponseFuture<Empty> unimplementedCall(Empty request,
       {CallOptions options}) {
-    final call = $createCall(_$unimplementedCall, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(
+        _$unimplementedCall, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 }
@@ -228,10 +217,9 @@ class UnimplementedServiceClient extends Client {
 
   ResponseFuture<Empty> unimplementedCall(Empty request,
       {CallOptions options}) {
-    final call = $createCall(_$unimplementedCall, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(
+        _$unimplementedCall, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 }
@@ -271,18 +259,14 @@ class ReconnectServiceClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<Empty> start(ReconnectParams request, {CallOptions options}) {
-    final call = $createCall(_$start, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$start, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseFuture<ReconnectInfo> stop(Empty request, {CallOptions options}) {
-    final call = $createCall(_$stop, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$stop, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -276,8 +276,7 @@ void main() {
   });
 
   test('Connection errors are reported', () async {
-    reset(harness.channel);
-    when(harness.channel.connect()).thenThrow('Connection error');
+    harness.channel.connectionError = 'Connection error';
     final expectedError =
         new GrpcError.unavailable('Error connecting: Connection error');
     harness.expectThrows(harness.client.unary(dummyValue), expectedError);

--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -47,32 +47,27 @@ class TestClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<int> unary(int request, {CallOptions options}) {
-    final call = $createCall(_$unary, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$unary, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseFuture<int> clientStreaming(Stream<int> request,
       {CallOptions options}) {
-    final call = $createCall(_$clientStreaming, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$clientStreaming, request, options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<int> serverStreaming(int request, {CallOptions options}) {
-    final call = $createCall(_$serverStreaming, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(
+        _$serverStreaming, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseStream(call);
   }
 
   ResponseStream<int> bidirectional(Stream<int> request,
       {CallOptions options}) {
-    final call = $createCall(_$bidirectional, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$bidirectional, request, options: options);
     return new ResponseStream(call);
   }
 }

--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -143,10 +143,11 @@ class ServerHarness {
 
   void sendRequestHeader(String path,
       {String authority = 'test',
-      String timeout,
-      Map<String, String> metadata}) {
-    final headers = ClientCall.createCallHeaders(path, authority,
-        timeout: timeout, metadata: metadata);
+      Map<String, String> metadata,
+      Duration timeout}) {
+    final options = new CallOptions(metadata: metadata, timeout: timeout);
+    final headers =
+        ClientConnection.createCallHeaders(true, authority, path, options);
     toServer.add(new HeadersStreamMessage(headers));
   }
 

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -25,7 +25,7 @@ void validateRequestHeaders(List<Header> headers,
     Map<String, String> customHeaders}) {
   final headerMap = headersToMap(headers);
   expect(headerMap[':method'], 'POST');
-  expect(headerMap[':scheme'], 'http');
+  expect(headerMap[':scheme'], 'https');
   if (path != null) {
     expect(headerMap[':path'], path);
   }

--- a/test/timeout_test.dart
+++ b/test/timeout_test.dart
@@ -132,7 +132,8 @@ void main() {
       harness
         ..service.unaryHandler = methodHandler
         ..expectErrorResponse(StatusCode.deadlineExceeded, 'Deadline exceeded')
-        ..sendRequestHeader('/Test/Unary', metadata: {'grpc-timeout': '1u'});
+        ..sendRequestHeader('/Test/Unary',
+            timeout: new Duration(microseconds: 1));
       await harness.fromServer.done;
     });
   });


### PR DESCRIPTION
First stage of separating Connection from Channel. A Channel manages
multiple Connections, and chooses which Connection to send an RPC on.

In this change, the Channel still creates a Connection for each RPC.
Managing the Connection life-cycle comes in a later change.