### PR TITLE
Multiplex RPCs on a single connection.

### DIFF
--- a/example/route_guide/lib/src/client.dart
+++ b/example/route_guide/lib/src/client.dart
@@ -18,12 +18,17 @@ class Client {
   Future<Null> main(List<String> args) async {
     channel = new ClientChannel('127.0.0.1',
         port: 8080, options: const ChannelOptions.insecure());
-    stub = new RouteGuideClient(channel);
+    stub = new RouteGuideClient(channel,
+        options: new CallOptions(timeout: new Duration(seconds: 30)));
     // Run all of the demos in order.
-    await runGetFeature();
-    await runListFeatures();
-    await runRecordRoute();
-    await runRouteChat();
+    try {
+      await runGetFeature();
+      await runListFeatures();
+      await runRecordRoute();
+      await runRouteChat();
+    } catch (e) {
+      print('Caught error: $e');
+    }
     await channel.shutdown();
   }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -271,8 +271,8 @@ class ClientConnection {
   }
 
   void _handleIdleTimeout() {
-    if (_timer == null) return;
-    _timer = null;
+    if (_timer == null || _state != ConnectionState.ready) return;
+    _cancelTimer();
     _transport?.finish()?.catchError((_) => {}); // TODO(jakobr): Log error.
     _transport = null;
     _setState(ConnectionState.idle);
@@ -307,7 +307,6 @@ class ClientConnection {
     // TODO(jakobr): Log error.
     _cancelTimer();
     if (!_hasPendingCalls()) {
-      // If there are no pending calls, just go directly to idle.
       _setState(ConnectionState.idle);
       return;
     }
@@ -317,8 +316,8 @@ class ClientConnection {
   }
 
   void _handleReconnect() {
-    if (_timer == null) return;
-    _timer = null;
+    if (_timer == null || _state != ConnectionState.transientFailure) return;
+    _cancelTimer();
     _connect();
   }
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -112,6 +112,8 @@ class Server {
     server.listen((socket) {
       final connection = new ServerTransportConnection.viaSocket(socket);
       _connections.add(connection);
+      // TODO(jakobr): Set active state handlers, close connection after idle
+      // timeout.
       connection.incomingStreams.listen(serveStream, onError: (error) {
         print('Connection error: $error');
       }, onDone: () {

--- a/lib/src/shared.dart
+++ b/lib/src/shared.dart
@@ -124,10 +124,12 @@ abstract class _ResponseMixin<Q, R> implements Response {
   Future<Null> cancel() => _call.cancel();
 }
 
+const supportedAlpnProtocols = const ['grpc-exp', 'h2'];
+
 // TODO: Simplify once we have a stable Dart 1.25 release (update pubspec to
 // require SDK >=1.25.0, and remove check for alpnSupported).
 SecurityContext createSecurityContext(bool isServer) =>
     SecurityContext.alpnSupported
         ? (new SecurityContext()
-          ..setAlpnProtocols(['grpc-exp', 'h2'], isServer))
+          ..setAlpnProtocols(supportedAlpnProtocols, isServer))
         : new SecurityContext();

--- a/lib/src/streams.dart
+++ b/lib/src/streams.dart
@@ -148,6 +148,7 @@ class _GrpcMessageConversionSink extends ChunkedConversionSink<StreamMessage> {
       // TODO(jakobr): Handle duplicate header names correctly.
       headers[ASCII.decode(header.name)] = ASCII.decode(header.value);
     }
+    // TODO(jakobr): Check :status, go to error mode if not 2xx.
     _out.add(new GrpcMetadata(headers));
   }
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -344,9 +344,12 @@ void main() {
   });
 
   test('Connections time out if idle', () async {
+    final done = new Completer();
     final connectionStates = <ConnectionState>[];
     harness.connection.onStateChanged = (connection) {
-      connectionStates.add(connection.state);
+      final state = connection.state;
+      connectionStates.add(state);
+      if (state == ConnectionState.idle) done.complete();
     };
 
     harness.channelOptions.idleTimeout = const Duration(microseconds: 10);
@@ -355,7 +358,7 @@ void main() {
     harness.signalIdle();
     expect(
         connectionStates, [ConnectionState.connecting, ConnectionState.ready]);
-    await new Future.delayed(const Duration(microseconds: 100));
+    await done.future;
     expect(connectionStates, [
       ConnectionState.connecting,
       ConnectionState.ready,

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -4,10 +4,9 @@
 
 import 'dart:async';
 
-import 'package:grpc/src/status.dart';
+import 'package:grpc/grpc.dart';
 import 'package:http2/transport.dart';
 import 'package:test/test.dart';
-import 'package:mockito/mockito.dart';
 
 import 'src/client_utils.dart';
 import 'src/utils.dart';
@@ -275,15 +274,6 @@ void main() {
     );
   });
 
-  test('Connection errors are reported', () async {
-    harness.channel.connectionError = 'Connection error';
-    final expectedError =
-        new GrpcError.unavailable('Error connecting: Connection error');
-    harness.expectThrows(harness.client.unary(dummyValue), expectedError);
-    harness.expectThrows(
-        harness.client.serverStreaming(dummyValue).toList(), expectedError);
-  });
-
   test('Known request errors are reported', () async {
     final expectedException = new GrpcError.deadlineExceeded('Too late!');
 
@@ -309,5 +299,83 @@ void main() {
       expectedException: expectedException,
       expectDone: false,
     );
+  });
+
+  Future<Null> makeUnaryCall() async {
+    void handleRequest(StreamMessage message) {
+      harness
+        ..sendResponseHeader()
+        ..sendResponseValue(1)
+        ..sendResponseTrailer();
+    }
+
+    await harness.runTest(
+      clientCall: harness.client.unary(1),
+      expectedResult: 1,
+      expectedPath: '/Test/Unary',
+      serverHandlers: [handleRequest],
+    );
+  }
+
+  test('Reconnect on connection error', () async {
+    final connectionStates = <ConnectionState>[];
+    harness.connection.connectionError = 'Connection error';
+    int failureCount = 0;
+    harness.connection.onStateChanged = (connection) {
+      final state = connection.state;
+      connectionStates.add(state);
+      if (state == ConnectionState.transientFailure) failureCount++;
+      if (failureCount == 2) {
+        harness.connection.connectionError = null;
+      }
+    };
+
+    await makeUnaryCall();
+
+    expect(failureCount, 2);
+    expect(connectionStates, [
+      ConnectionState.connecting,
+      ConnectionState.transientFailure,
+      ConnectionState.connecting,
+      ConnectionState.transientFailure,
+      ConnectionState.connecting,
+      ConnectionState.ready
+    ]);
+  });
+
+  test('Connections time out if idle', () async {
+    final connectionStates = <ConnectionState>[];
+    harness.connection.onStateChanged = (connection) {
+      connectionStates.add(connection.state);
+    };
+
+    harness.channelOptions.idleTimeout = const Duration(microseconds: 10);
+
+    await makeUnaryCall();
+    harness.signalIdle();
+    expect(
+        connectionStates, [ConnectionState.connecting, ConnectionState.ready]);
+    await new Future.delayed(const Duration(microseconds: 100));
+    expect(connectionStates, [
+      ConnectionState.connecting,
+      ConnectionState.ready,
+      ConnectionState.idle
+    ]);
+  });
+
+  test('Default reconnect backoff backs off', () {
+    Duration lastBackoff = defaultBackoffStrategy(null);
+    expect(lastBackoff, const Duration(seconds: 1));
+    for (int i = 0; i < 12; i++) {
+      final minNext = lastBackoff * (1.6 - 0.2);
+      final maxNext = lastBackoff * (1.6 + 0.2);
+      lastBackoff = defaultBackoffStrategy(lastBackoff);
+      if (lastBackoff != const Duration(minutes: 2)) {
+        expect(lastBackoff, greaterThanOrEqualTo(minNext));
+        expect(lastBackoff, lessThanOrEqualTo(maxNext));
+      }
+    }
+    expect(lastBackoff, const Duration(minutes: 2));
+    expect(defaultBackoffStrategy(lastBackoff), const Duration(minutes: 2));
   });
 }

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -26,9 +26,6 @@ void main() {
       final correctPassword = new ChannelOptions.secure(
           certificate: certificate, password: 'correct');
       expect(correctPassword.securityContext, isNotNull);
-
-      final channel = new ClientChannel('localhost', options: missingPassword);
-      expect(channel.connect(), throwsA(isTlsException));
     });
   });
 }


### PR DESCRIPTION
A Channel will now multiplex RPCs on a single managed connection. The
connection will attempt to reconnect on failure, and will close the
underlying transport connection if no RPCs have been made for a while.

Part of #5.