### PR TITLE
Added support for metadata providers.

### DIFF
--- a/example/googleapis/.gitignore
+++ b/example/googleapis/.gitignore
@@ -1,0 +1,1 @@
+logging-service-account.json

--- a/example/googleapis/README.md
+++ b/example/googleapis/README.md
@@ -1,0 +1,64 @@
+# Description
+The googleapis client demonstrates how to use Dart gRPC libraries to communicate
+with Google APIs.
+
+# Set up Google Cloud Platform project
+
+This example uses the Stackdriver Logging API. Please follow the documentation on
+[Stackdriver Logging Documentation](https://cloud.google.com/logging/docs/) to create
+a project and enable the logging API.
+
+Then follow the documentation to
+[create a service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount).
+This example uses the Logging/Logs Writer role.
+ 
+Create a new service key, download the JSON file for it, and save it as
+`logging-service-account.json`.
+
+# Run the sample code
+To run the example, assuming you are in the root of the googleapis folder, i.e.,
+.../example/googleapis/, first get the dependencies by running:
+
+```sh
+$ pub get
+```
+
+Then, to run the logging client sample:
+
+```sh
+$ pub run googleapis:logging
+```
+
+# Regenerate the stubs
+
+The Dart gRPC stubs and message classes are generated based on protobuf definition
+files from [googleapis/googleapis](https://github.com/googleapis/googleapis).
+
+To regenerate them, you will need to check out both
+[googleapis/googleapis](https://github.com/googleapis/googleapis) and
+[google/protobuf](https://github.com/google/protobuf).
+
+You will also need to have protoc version 3.0.0 or higher and the Dart protoc
+plugin version 0.7.8 or higher on your PATH.
+
+To install protoc, see the instructions on
+[the Protocol Buffers website](https://developers.google.com/protocol-buffers/).
+
+The easiest way to get the Dart protoc plugin is by running
+
+```sh
+$ pub global activate protoc_plugin
+```
+
+and follow the directions to add `~/.pub-cache/bin` to your PATH, if you haven't
+already done so.
+
+You can now regenerate the Dart files. Set the `PROTOBUF` and `GOOGLEAPIS`
+environment variables to point to your clone of
+[google/protobuf](https://github.com/google/protobuf) and
+[googleapis/googleapis](https://github.com/googleapis/googleapis), respectively,
+and then run
+ 
+```sh
+$ tool/regenerate.sh
+```

--- a/example/googleapis/bin/logging.dart
+++ b/example/googleapis/bin/logging.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:googleapis_auth/auth_io.dart' as auth;
+import 'package:grpc/grpc.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:googleapis/src/generated/google/api/monitored_resource.pb.dart';
+import 'package:googleapis/src/generated/google/logging/type/log_severity.pb.dart';
+import 'package:googleapis/src/generated/google/logging/v2/log_entry.pb.dart';
+import 'package:googleapis/src/generated/google/logging/v2/logging.pbgrpc.dart';
+
+const _tokenExpirationThreshold = const Duration(seconds: 30);
+
+class ServiceAccountAuthenticator {
+  auth.ServiceAccountCredentials _serviceAccountCredentials;
+  final List<String> _scopes;
+  String _projectId;
+
+  auth.AccessToken _accessToken;
+  Future<CallOptions> _call;
+
+  ServiceAccountAuthenticator(String serviceAccountJson, this._scopes) {
+    final serviceAccount = JSON.decode(serviceAccountJson);
+    _serviceAccountCredentials =
+        new auth.ServiceAccountCredentials.fromJson(serviceAccount);
+    _projectId = serviceAccount['project_id'];
+  }
+
+  String get projectId => _projectId;
+
+  Future authenticate(Map<String, String> metadata) async {
+    if (_accessToken == null || _accessToken.hasExpired) {
+      await _obtainAccessCredentials();
+    }
+
+    metadata['authorization'] = 'Bearer ${_accessToken.data}';
+
+    if (_tokenExpiresSoon) {
+      // Token is about to expire. Extend it prematurely.
+      _obtainAccessCredentials().catchError((_) {});
+    }
+  }
+
+  bool get _tokenExpiresSoon => _accessToken.expiry
+      .subtract(_tokenExpirationThreshold)
+      .isBefore(new DateTime.now().toUtc());
+
+  Future _obtainAccessCredentials() {
+    if (_call == null) {
+      final authClient = new http.Client();
+      _call = auth
+          .obtainAccessCredentialsViaServiceAccount(
+              _serviceAccountCredentials, _scopes, authClient)
+          .then((credentials) {
+        _accessToken = credentials.accessToken;
+        _call = null;
+        authClient.close();
+      });
+    }
+    return _call;
+  }
+
+  CallOptions get toCallOptions => new CallOptions(providers: [authenticate]);
+}
+
+Future<Null> main() async {
+  final serviceAccountFile = new File('logging-service-account.json');
+  if (!serviceAccountFile.existsSync()) {
+    print('File logging-service-account.json not found. Please follow the '
+        'steps in README.md to create it.');
+    exit(-1);
+  }
+
+  final scopes = [
+    'https://www.googleapis.com/auth/cloud-platform',
+    'https://www.googleapis.com/auth/logging.write',
+  ];
+
+  final authenticator = new ServiceAccountAuthenticator(
+      serviceAccountFile.readAsStringSync(), scopes);
+  final projectId = authenticator.projectId;
+
+  final channel = new ClientChannel('logging.googleapis.com',
+      options: const ChannelOptions.secure());
+  final logging =
+      new LoggingServiceV2Client(channel, options: authenticator.toCallOptions);
+
+  final request = new WriteLogEntriesRequest()
+    ..entries.add(new LogEntry()
+      ..logName = 'projects/$projectId/logs/example'
+      ..severity = LogSeverity.INFO
+      ..resource = (new MonitoredResource()..type = 'global')
+      ..textPayload = 'This is a log entry!');
+  await logging.writeLogEntries(request);
+
+  await channel.shutdown();
+}

--- a/example/googleapis/lib/src/generated/google/api/label.pb.dart
+++ b/example/googleapis/lib/src/generated/google/api/label.pb.dart
@@ -1,0 +1,78 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.api_label;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+import 'label.pbenum.dart';
+
+export 'label.pbenum.dart';
+
+class LabelDescriptor extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('LabelDescriptor')
+    ..a<String>(1, 'key', PbFieldType.OS)
+    ..e<LabelDescriptor_ValueType>(
+        2,
+        'valueType',
+        PbFieldType.OE,
+        LabelDescriptor_ValueType.STRING,
+        LabelDescriptor_ValueType.valueOf,
+        LabelDescriptor_ValueType.values)
+    ..a<String>(3, 'description', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  LabelDescriptor() : super();
+  LabelDescriptor.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  LabelDescriptor.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  LabelDescriptor clone() => new LabelDescriptor()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static LabelDescriptor create() => new LabelDescriptor();
+  static PbList<LabelDescriptor> createRepeated() =>
+      new PbList<LabelDescriptor>();
+  static LabelDescriptor getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyLabelDescriptor();
+    return _defaultInstance;
+  }
+
+  static LabelDescriptor _defaultInstance;
+  static void $checkItem(LabelDescriptor v) {
+    if (v is! LabelDescriptor) checkItemFailed(v, 'LabelDescriptor');
+  }
+
+  String get key => $_get(0, 1, '');
+  set key(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasKey() => $_has(0, 1);
+  void clearKey() => clearField(1);
+
+  LabelDescriptor_ValueType get valueType => $_get(1, 2, null);
+  set valueType(LabelDescriptor_ValueType v) {
+    setField(2, v);
+  }
+
+  bool hasValueType() => $_has(1, 2);
+  void clearValueType() => clearField(2);
+
+  String get description => $_get(2, 3, '');
+  set description(String v) {
+    $_setString(2, 3, v);
+  }
+
+  bool hasDescription() => $_has(2, 3);
+  void clearDescription() => clearField(3);
+}
+
+class _ReadonlyLabelDescriptor extends LabelDescriptor
+    with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/api/label.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/api/label.pbenum.dart
@@ -1,0 +1,35 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.api_label_pbenum;
+
+// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
+import 'dart:core' show int, dynamic, String, List, Map;
+import 'package:protobuf/protobuf.dart';
+
+class LabelDescriptor_ValueType extends ProtobufEnum {
+  static const LabelDescriptor_ValueType STRING =
+      const LabelDescriptor_ValueType._(0, 'STRING');
+  static const LabelDescriptor_ValueType BOOL =
+      const LabelDescriptor_ValueType._(1, 'BOOL');
+  static const LabelDescriptor_ValueType INT64 =
+      const LabelDescriptor_ValueType._(2, 'INT64');
+
+  static const List<LabelDescriptor_ValueType> values =
+      const <LabelDescriptor_ValueType>[
+    STRING,
+    BOOL,
+    INT64,
+  ];
+
+  static final Map<int, dynamic> _byValue = ProtobufEnum.initByValue(values);
+  static LabelDescriptor_ValueType valueOf(int value) =>
+      _byValue[value] as LabelDescriptor_ValueType;
+  static void $checkItem(LabelDescriptor_ValueType v) {
+    if (v is! LabelDescriptor_ValueType)
+      checkItemFailed(v, 'LabelDescriptor_ValueType');
+  }
+
+  const LabelDescriptor_ValueType._(int v, String n) : super(v, n);
+}

--- a/example/googleapis/lib/src/generated/google/api/label.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/api/label.pbjson.dart
@@ -1,0 +1,31 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.api_label_pbjson;
+
+const LabelDescriptor$json = const {
+  '1': 'LabelDescriptor',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {
+      '1': 'value_type',
+      '3': 2,
+      '4': 1,
+      '5': 14,
+      '6': '.google.api.LabelDescriptor.ValueType',
+      '10': 'valueType'
+    },
+    const {'1': 'description', '3': 3, '4': 1, '5': 9, '10': 'description'},
+  ],
+  '4': const [LabelDescriptor_ValueType$json],
+};
+
+const LabelDescriptor_ValueType$json = const {
+  '1': 'ValueType',
+  '2': const [
+    const {'1': 'STRING', '2': 0},
+    const {'1': 'BOOL', '2': 1},
+    const {'1': 'INT64', '2': 2},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/api/monitored_resource.pb.dart
+++ b/example/googleapis/lib/src/generated/google/api/monitored_resource.pb.dart
@@ -1,0 +1,186 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.api_monitored_resource;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+import 'label.pb.dart';
+
+class MonitoredResourceDescriptor extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('MonitoredResourceDescriptor')
+    ..a<String>(1, 'type', PbFieldType.OS)
+    ..a<String>(2, 'displayName', PbFieldType.OS)
+    ..a<String>(3, 'description', PbFieldType.OS)
+    ..pp<LabelDescriptor>(4, 'labels', PbFieldType.PM,
+        LabelDescriptor.$checkItem, LabelDescriptor.create)
+    ..a<String>(5, 'name', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  MonitoredResourceDescriptor() : super();
+  MonitoredResourceDescriptor.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  MonitoredResourceDescriptor.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  MonitoredResourceDescriptor clone() =>
+      new MonitoredResourceDescriptor()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static MonitoredResourceDescriptor create() =>
+      new MonitoredResourceDescriptor();
+  static PbList<MonitoredResourceDescriptor> createRepeated() =>
+      new PbList<MonitoredResourceDescriptor>();
+  static MonitoredResourceDescriptor getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyMonitoredResourceDescriptor();
+    return _defaultInstance;
+  }
+
+  static MonitoredResourceDescriptor _defaultInstance;
+  static void $checkItem(MonitoredResourceDescriptor v) {
+    if (v is! MonitoredResourceDescriptor)
+      checkItemFailed(v, 'MonitoredResourceDescriptor');
+  }
+
+  String get type => $_get(0, 1, '');
+  set type(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasType() => $_has(0, 1);
+  void clearType() => clearField(1);
+
+  String get displayName => $_get(1, 2, '');
+  set displayName(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasDisplayName() => $_has(1, 2);
+  void clearDisplayName() => clearField(2);
+
+  String get description => $_get(2, 3, '');
+  set description(String v) {
+    $_setString(2, 3, v);
+  }
+
+  bool hasDescription() => $_has(2, 3);
+  void clearDescription() => clearField(3);
+
+  List<LabelDescriptor> get labels => $_get(3, 4, null);
+
+  String get name => $_get(4, 5, '');
+  set name(String v) {
+    $_setString(4, 5, v);
+  }
+
+  bool hasName() => $_has(4, 5);
+  void clearName() => clearField(5);
+}
+
+class _ReadonlyMonitoredResourceDescriptor extends MonitoredResourceDescriptor
+    with ReadonlyMessageMixin {}
+
+class MonitoredResource_LabelsEntry extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('MonitoredResource_LabelsEntry')
+    ..a<String>(1, 'key', PbFieldType.OS)
+    ..a<String>(2, 'value', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  MonitoredResource_LabelsEntry() : super();
+  MonitoredResource_LabelsEntry.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  MonitoredResource_LabelsEntry.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  MonitoredResource_LabelsEntry clone() =>
+      new MonitoredResource_LabelsEntry()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static MonitoredResource_LabelsEntry create() =>
+      new MonitoredResource_LabelsEntry();
+  static PbList<MonitoredResource_LabelsEntry> createRepeated() =>
+      new PbList<MonitoredResource_LabelsEntry>();
+  static MonitoredResource_LabelsEntry getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyMonitoredResource_LabelsEntry();
+    return _defaultInstance;
+  }
+
+  static MonitoredResource_LabelsEntry _defaultInstance;
+  static void $checkItem(MonitoredResource_LabelsEntry v) {
+    if (v is! MonitoredResource_LabelsEntry)
+      checkItemFailed(v, 'MonitoredResource_LabelsEntry');
+  }
+
+  String get key => $_get(0, 1, '');
+  set key(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasKey() => $_has(0, 1);
+  void clearKey() => clearField(1);
+
+  String get value => $_get(1, 2, '');
+  set value(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasValue() => $_has(1, 2);
+  void clearValue() => clearField(2);
+}
+
+class _ReadonlyMonitoredResource_LabelsEntry
+    extends MonitoredResource_LabelsEntry with ReadonlyMessageMixin {}
+
+class MonitoredResource extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('MonitoredResource')
+    ..a<String>(1, 'type', PbFieldType.OS)
+    ..pp<MonitoredResource_LabelsEntry>(
+        2,
+        'labels',
+        PbFieldType.PM,
+        MonitoredResource_LabelsEntry.$checkItem,
+        MonitoredResource_LabelsEntry.create)
+    ..hasRequiredFields = false;
+
+  MonitoredResource() : super();
+  MonitoredResource.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  MonitoredResource.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  MonitoredResource clone() => new MonitoredResource()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static MonitoredResource create() => new MonitoredResource();
+  static PbList<MonitoredResource> createRepeated() =>
+      new PbList<MonitoredResource>();
+  static MonitoredResource getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyMonitoredResource();
+    return _defaultInstance;
+  }
+
+  static MonitoredResource _defaultInstance;
+  static void $checkItem(MonitoredResource v) {
+    if (v is! MonitoredResource) checkItemFailed(v, 'MonitoredResource');
+  }
+
+  String get type => $_get(0, 1, '');
+  set type(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasType() => $_has(0, 1);
+  void clearType() => clearField(1);
+
+  List<MonitoredResource_LabelsEntry> get labels => $_get(1, 2, null);
+}
+
+class _ReadonlyMonitoredResource extends MonitoredResource
+    with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/api/monitored_resource.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/api/monitored_resource.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.api_monitored_resource_pbenum;

--- a/example/googleapis/lib/src/generated/google/api/monitored_resource.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/api/monitored_resource.pbjson.dart
@@ -1,0 +1,48 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.api_monitored_resource_pbjson;
+
+const MonitoredResourceDescriptor$json = const {
+  '1': 'MonitoredResourceDescriptor',
+  '2': const [
+    const {'1': 'name', '3': 5, '4': 1, '5': 9, '10': 'name'},
+    const {'1': 'type', '3': 1, '4': 1, '5': 9, '10': 'type'},
+    const {'1': 'display_name', '3': 2, '4': 1, '5': 9, '10': 'displayName'},
+    const {'1': 'description', '3': 3, '4': 1, '5': 9, '10': 'description'},
+    const {
+      '1': 'labels',
+      '3': 4,
+      '4': 3,
+      '5': 11,
+      '6': '.google.api.LabelDescriptor',
+      '10': 'labels'
+    },
+  ],
+};
+
+const MonitoredResource$json = const {
+  '1': 'MonitoredResource',
+  '2': const [
+    const {'1': 'type', '3': 1, '4': 1, '5': 9, '10': 'type'},
+    const {
+      '1': 'labels',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.google.api.MonitoredResource.LabelsEntry',
+      '10': 'labels'
+    },
+  ],
+  '3': const [MonitoredResource_LabelsEntry$json],
+};
+
+const MonitoredResource_LabelsEntry$json = const {
+  '1': 'LabelsEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  ],
+  '7': const {'7': true},
+};

--- a/example/googleapis/lib/src/generated/google/logging/type/http_request.pb.dart
+++ b/example/googleapis/lib/src/generated/google/logging/type/http_request.pb.dart
@@ -1,0 +1,177 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.type_http_request;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:fixnum/fixnum.dart';
+import 'package:protobuf/protobuf.dart';
+
+import '../../protobuf/duration.pb.dart' as $google$protobuf;
+
+class HttpRequest extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('HttpRequest')
+    ..a<String>(1, 'requestMethod', PbFieldType.OS)
+    ..a<String>(2, 'requestUrl', PbFieldType.OS)
+    ..a<Int64>(3, 'requestSize', PbFieldType.O6, Int64.ZERO)
+    ..a<int>(4, 'status', PbFieldType.O3)
+    ..a<Int64>(5, 'responseSize', PbFieldType.O6, Int64.ZERO)
+    ..a<String>(6, 'userAgent', PbFieldType.OS)
+    ..a<String>(7, 'remoteIp', PbFieldType.OS)
+    ..a<String>(8, 'referer', PbFieldType.OS)
+    ..a<bool>(9, 'cacheHit', PbFieldType.OB)
+    ..a<bool>(10, 'cacheValidatedWithOriginServer', PbFieldType.OB)
+    ..a<bool>(11, 'cacheLookup', PbFieldType.OB)
+    ..a<Int64>(12, 'cacheFillBytes', PbFieldType.O6, Int64.ZERO)
+    ..a<String>(13, 'serverIp', PbFieldType.OS)
+    ..a<$google$protobuf.Duration>(14, 'latency', PbFieldType.OM,
+        $google$protobuf.Duration.getDefault, $google$protobuf.Duration.create)
+    ..a<String>(15, 'protocol', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  HttpRequest() : super();
+  HttpRequest.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  HttpRequest.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  HttpRequest clone() => new HttpRequest()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static HttpRequest create() => new HttpRequest();
+  static PbList<HttpRequest> createRepeated() => new PbList<HttpRequest>();
+  static HttpRequest getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyHttpRequest();
+    return _defaultInstance;
+  }
+
+  static HttpRequest _defaultInstance;
+  static void $checkItem(HttpRequest v) {
+    if (v is! HttpRequest) checkItemFailed(v, 'HttpRequest');
+  }
+
+  String get requestMethod => $_get(0, 1, '');
+  set requestMethod(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasRequestMethod() => $_has(0, 1);
+  void clearRequestMethod() => clearField(1);
+
+  String get requestUrl => $_get(1, 2, '');
+  set requestUrl(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasRequestUrl() => $_has(1, 2);
+  void clearRequestUrl() => clearField(2);
+
+  Int64 get requestSize => $_get(2, 3, null);
+  set requestSize(Int64 v) {
+    $_setInt64(2, 3, v);
+  }
+
+  bool hasRequestSize() => $_has(2, 3);
+  void clearRequestSize() => clearField(3);
+
+  int get status => $_get(3, 4, 0);
+  set status(int v) {
+    $_setUnsignedInt32(3, 4, v);
+  }
+
+  bool hasStatus() => $_has(3, 4);
+  void clearStatus() => clearField(4);
+
+  Int64 get responseSize => $_get(4, 5, null);
+  set responseSize(Int64 v) {
+    $_setInt64(4, 5, v);
+  }
+
+  bool hasResponseSize() => $_has(4, 5);
+  void clearResponseSize() => clearField(5);
+
+  String get userAgent => $_get(5, 6, '');
+  set userAgent(String v) {
+    $_setString(5, 6, v);
+  }
+
+  bool hasUserAgent() => $_has(5, 6);
+  void clearUserAgent() => clearField(6);
+
+  String get remoteIp => $_get(6, 7, '');
+  set remoteIp(String v) {
+    $_setString(6, 7, v);
+  }
+
+  bool hasRemoteIp() => $_has(6, 7);
+  void clearRemoteIp() => clearField(7);
+
+  String get referer => $_get(7, 8, '');
+  set referer(String v) {
+    $_setString(7, 8, v);
+  }
+
+  bool hasReferer() => $_has(7, 8);
+  void clearReferer() => clearField(8);
+
+  bool get cacheHit => $_get(8, 9, false);
+  set cacheHit(bool v) {
+    $_setBool(8, 9, v);
+  }
+
+  bool hasCacheHit() => $_has(8, 9);
+  void clearCacheHit() => clearField(9);
+
+  bool get cacheValidatedWithOriginServer => $_get(9, 10, false);
+  set cacheValidatedWithOriginServer(bool v) {
+    $_setBool(9, 10, v);
+  }
+
+  bool hasCacheValidatedWithOriginServer() => $_has(9, 10);
+  void clearCacheValidatedWithOriginServer() => clearField(10);
+
+  bool get cacheLookup => $_get(10, 11, false);
+  set cacheLookup(bool v) {
+    $_setBool(10, 11, v);
+  }
+
+  bool hasCacheLookup() => $_has(10, 11);
+  void clearCacheLookup() => clearField(11);
+
+  Int64 get cacheFillBytes => $_get(11, 12, null);
+  set cacheFillBytes(Int64 v) {
+    $_setInt64(11, 12, v);
+  }
+
+  bool hasCacheFillBytes() => $_has(11, 12);
+  void clearCacheFillBytes() => clearField(12);
+
+  String get serverIp => $_get(12, 13, '');
+  set serverIp(String v) {
+    $_setString(12, 13, v);
+  }
+
+  bool hasServerIp() => $_has(12, 13);
+  void clearServerIp() => clearField(13);
+
+  $google$protobuf.Duration get latency => $_get(13, 14, null);
+  set latency($google$protobuf.Duration v) {
+    setField(14, v);
+  }
+
+  bool hasLatency() => $_has(13, 14);
+  void clearLatency() => clearField(14);
+
+  String get protocol => $_get(14, 15, '');
+  set protocol(String v) {
+    $_setString(14, 15, v);
+  }
+
+  bool hasProtocol() => $_has(14, 15);
+  void clearProtocol() => clearField(15);
+}
+
+class _ReadonlyHttpRequest extends HttpRequest with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/logging/type/http_request.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/logging/type/http_request.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.type_http_request_pbenum;

--- a/example/googleapis/lib/src/generated/google/logging/type/http_request.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/logging/type/http_request.pbjson.dart
@@ -1,0 +1,51 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.type_http_request_pbjson;
+
+const HttpRequest$json = const {
+  '1': 'HttpRequest',
+  '2': const [
+    const {
+      '1': 'request_method',
+      '3': 1,
+      '4': 1,
+      '5': 9,
+      '10': 'requestMethod'
+    },
+    const {'1': 'request_url', '3': 2, '4': 1, '5': 9, '10': 'requestUrl'},
+    const {'1': 'request_size', '3': 3, '4': 1, '5': 3, '10': 'requestSize'},
+    const {'1': 'status', '3': 4, '4': 1, '5': 5, '10': 'status'},
+    const {'1': 'response_size', '3': 5, '4': 1, '5': 3, '10': 'responseSize'},
+    const {'1': 'user_agent', '3': 6, '4': 1, '5': 9, '10': 'userAgent'},
+    const {'1': 'remote_ip', '3': 7, '4': 1, '5': 9, '10': 'remoteIp'},
+    const {'1': 'server_ip', '3': 13, '4': 1, '5': 9, '10': 'serverIp'},
+    const {'1': 'referer', '3': 8, '4': 1, '5': 9, '10': 'referer'},
+    const {
+      '1': 'latency',
+      '3': 14,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Duration',
+      '10': 'latency'
+    },
+    const {'1': 'cache_lookup', '3': 11, '4': 1, '5': 8, '10': 'cacheLookup'},
+    const {'1': 'cache_hit', '3': 9, '4': 1, '5': 8, '10': 'cacheHit'},
+    const {
+      '1': 'cache_validated_with_origin_server',
+      '3': 10,
+      '4': 1,
+      '5': 8,
+      '10': 'cacheValidatedWithOriginServer'
+    },
+    const {
+      '1': 'cache_fill_bytes',
+      '3': 12,
+      '4': 1,
+      '5': 3,
+      '10': 'cacheFillBytes'
+    },
+    const {'1': 'protocol', '3': 15, '4': 1, '5': 9, '10': 'protocol'},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/logging/type/log_severity.pb.dart
+++ b/example/googleapis/lib/src/generated/google/logging/type/log_severity.pb.dart
@@ -1,0 +1,10 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.type_log_severity;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+export 'log_severity.pbenum.dart';

--- a/example/googleapis/lib/src/generated/google/logging/type/log_severity.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/logging/type/log_severity.pbenum.dart
@@ -1,0 +1,41 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.type_log_severity_pbenum;
+
+// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
+import 'dart:core' show int, dynamic, String, List, Map;
+import 'package:protobuf/protobuf.dart';
+
+class LogSeverity extends ProtobufEnum {
+  static const LogSeverity DEFAULT = const LogSeverity._(0, 'DEFAULT');
+  static const LogSeverity DEBUG = const LogSeverity._(100, 'DEBUG');
+  static const LogSeverity INFO = const LogSeverity._(200, 'INFO');
+  static const LogSeverity NOTICE = const LogSeverity._(300, 'NOTICE');
+  static const LogSeverity WARNING = const LogSeverity._(400, 'WARNING');
+  static const LogSeverity ERROR = const LogSeverity._(500, 'ERROR');
+  static const LogSeverity CRITICAL = const LogSeverity._(600, 'CRITICAL');
+  static const LogSeverity ALERT = const LogSeverity._(700, 'ALERT');
+  static const LogSeverity EMERGENCY = const LogSeverity._(800, 'EMERGENCY');
+
+  static const List<LogSeverity> values = const <LogSeverity>[
+    DEFAULT,
+    DEBUG,
+    INFO,
+    NOTICE,
+    WARNING,
+    ERROR,
+    CRITICAL,
+    ALERT,
+    EMERGENCY,
+  ];
+
+  static final Map<int, dynamic> _byValue = ProtobufEnum.initByValue(values);
+  static LogSeverity valueOf(int value) => _byValue[value] as LogSeverity;
+  static void $checkItem(LogSeverity v) {
+    if (v is! LogSeverity) checkItemFailed(v, 'LogSeverity');
+  }
+
+  const LogSeverity._(int v, String n) : super(v, n);
+}

--- a/example/googleapis/lib/src/generated/google/logging/type/log_severity.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/logging/type/log_severity.pbjson.dart
@@ -1,0 +1,20 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.type_log_severity_pbjson;
+
+const LogSeverity$json = const {
+  '1': 'LogSeverity',
+  '2': const [
+    const {'1': 'DEFAULT', '2': 0},
+    const {'1': 'DEBUG', '2': 100},
+    const {'1': 'INFO', '2': 200},
+    const {'1': 'NOTICE', '2': 300},
+    const {'1': 'WARNING', '2': 400},
+    const {'1': 'ERROR', '2': 500},
+    const {'1': 'CRITICAL', '2': 600},
+    const {'1': 'ALERT', '2': 700},
+    const {'1': 'EMERGENCY', '2': 800},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/logging/v2/log_entry.pb.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/log_entry.pb.dart
@@ -1,0 +1,374 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_log_entry;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:fixnum/fixnum.dart';
+import 'package:protobuf/protobuf.dart';
+
+import '../../protobuf/any.pb.dart' as $google$protobuf;
+import '../../protobuf/struct.pb.dart' as $google$protobuf;
+import '../type/http_request.pb.dart' as $google$logging$type;
+import '../../api/monitored_resource.pb.dart' as $google$api;
+import '../../protobuf/timestamp.pb.dart' as $google$protobuf;
+
+import '../type/log_severity.pbenum.dart' as $google$logging$type;
+
+class LogEntry_LabelsEntry extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('LogEntry_LabelsEntry')
+    ..a<String>(1, 'key', PbFieldType.OS)
+    ..a<String>(2, 'value', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  LogEntry_LabelsEntry() : super();
+  LogEntry_LabelsEntry.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  LogEntry_LabelsEntry.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  LogEntry_LabelsEntry clone() =>
+      new LogEntry_LabelsEntry()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static LogEntry_LabelsEntry create() => new LogEntry_LabelsEntry();
+  static PbList<LogEntry_LabelsEntry> createRepeated() =>
+      new PbList<LogEntry_LabelsEntry>();
+  static LogEntry_LabelsEntry getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyLogEntry_LabelsEntry();
+    return _defaultInstance;
+  }
+
+  static LogEntry_LabelsEntry _defaultInstance;
+  static void $checkItem(LogEntry_LabelsEntry v) {
+    if (v is! LogEntry_LabelsEntry) checkItemFailed(v, 'LogEntry_LabelsEntry');
+  }
+
+  String get key => $_get(0, 1, '');
+  set key(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasKey() => $_has(0, 1);
+  void clearKey() => clearField(1);
+
+  String get value => $_get(1, 2, '');
+  set value(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasValue() => $_has(1, 2);
+  void clearValue() => clearField(2);
+}
+
+class _ReadonlyLogEntry_LabelsEntry extends LogEntry_LabelsEntry
+    with ReadonlyMessageMixin {}
+
+class LogEntry extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('LogEntry')
+    ..a<$google$protobuf.Any>(2, 'protoPayload', PbFieldType.OM,
+        $google$protobuf.Any.getDefault, $google$protobuf.Any.create)
+    ..a<String>(3, 'textPayload', PbFieldType.OS)
+    ..a<String>(4, 'insertId', PbFieldType.OS)
+    ..a<$google$protobuf.Struct>(6, 'jsonPayload', PbFieldType.OM,
+        $google$protobuf.Struct.getDefault, $google$protobuf.Struct.create)
+    ..a<$google$logging$type.HttpRequest>(
+        7,
+        'httpRequest',
+        PbFieldType.OM,
+        $google$logging$type.HttpRequest.getDefault,
+        $google$logging$type.HttpRequest.create)
+    ..a<$google$api.MonitoredResource>(
+        8,
+        'resource',
+        PbFieldType.OM,
+        $google$api.MonitoredResource.getDefault,
+        $google$api.MonitoredResource.create)
+    ..a<$google$protobuf.Timestamp>(
+        9,
+        'timestamp',
+        PbFieldType.OM,
+        $google$protobuf.Timestamp.getDefault,
+        $google$protobuf.Timestamp.create)
+    ..e<$google$logging$type.LogSeverity>(
+        10,
+        'severity',
+        PbFieldType.OE,
+        $google$logging$type.LogSeverity.DEFAULT,
+        $google$logging$type.LogSeverity.valueOf,
+        $google$logging$type.LogSeverity.values)
+    ..pp<LogEntry_LabelsEntry>(11, 'labels', PbFieldType.PM,
+        LogEntry_LabelsEntry.$checkItem, LogEntry_LabelsEntry.create)
+    ..a<String>(12, 'logName', PbFieldType.OS)
+    ..a<LogEntryOperation>(15, 'operation', PbFieldType.OM,
+        LogEntryOperation.getDefault, LogEntryOperation.create)
+    ..a<String>(22, 'trace', PbFieldType.OS)
+    ..a<LogEntrySourceLocation>(23, 'sourceLocation', PbFieldType.OM,
+        LogEntrySourceLocation.getDefault, LogEntrySourceLocation.create)
+    ..a<$google$protobuf.Timestamp>(
+        24,
+        'receiveTimestamp',
+        PbFieldType.OM,
+        $google$protobuf.Timestamp.getDefault,
+        $google$protobuf.Timestamp.create)
+    ..hasRequiredFields = false;
+
+  LogEntry() : super();
+  LogEntry.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  LogEntry.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  LogEntry clone() => new LogEntry()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static LogEntry create() => new LogEntry();
+  static PbList<LogEntry> createRepeated() => new PbList<LogEntry>();
+  static LogEntry getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyLogEntry();
+    return _defaultInstance;
+  }
+
+  static LogEntry _defaultInstance;
+  static void $checkItem(LogEntry v) {
+    if (v is! LogEntry) checkItemFailed(v, 'LogEntry');
+  }
+
+  $google$protobuf.Any get protoPayload => $_get(0, 2, null);
+  set protoPayload($google$protobuf.Any v) {
+    setField(2, v);
+  }
+
+  bool hasProtoPayload() => $_has(0, 2);
+  void clearProtoPayload() => clearField(2);
+
+  String get textPayload => $_get(1, 3, '');
+  set textPayload(String v) {
+    $_setString(1, 3, v);
+  }
+
+  bool hasTextPayload() => $_has(1, 3);
+  void clearTextPayload() => clearField(3);
+
+  String get insertId => $_get(2, 4, '');
+  set insertId(String v) {
+    $_setString(2, 4, v);
+  }
+
+  bool hasInsertId() => $_has(2, 4);
+  void clearInsertId() => clearField(4);
+
+  $google$protobuf.Struct get jsonPayload => $_get(3, 6, null);
+  set jsonPayload($google$protobuf.Struct v) {
+    setField(6, v);
+  }
+
+  bool hasJsonPayload() => $_has(3, 6);
+  void clearJsonPayload() => clearField(6);
+
+  $google$logging$type.HttpRequest get httpRequest => $_get(4, 7, null);
+  set httpRequest($google$logging$type.HttpRequest v) {
+    setField(7, v);
+  }
+
+  bool hasHttpRequest() => $_has(4, 7);
+  void clearHttpRequest() => clearField(7);
+
+  $google$api.MonitoredResource get resource => $_get(5, 8, null);
+  set resource($google$api.MonitoredResource v) {
+    setField(8, v);
+  }
+
+  bool hasResource() => $_has(5, 8);
+  void clearResource() => clearField(8);
+
+  $google$protobuf.Timestamp get timestamp => $_get(6, 9, null);
+  set timestamp($google$protobuf.Timestamp v) {
+    setField(9, v);
+  }
+
+  bool hasTimestamp() => $_has(6, 9);
+  void clearTimestamp() => clearField(9);
+
+  $google$logging$type.LogSeverity get severity => $_get(7, 10, null);
+  set severity($google$logging$type.LogSeverity v) {
+    setField(10, v);
+  }
+
+  bool hasSeverity() => $_has(7, 10);
+  void clearSeverity() => clearField(10);
+
+  List<LogEntry_LabelsEntry> get labels => $_get(8, 11, null);
+
+  String get logName => $_get(9, 12, '');
+  set logName(String v) {
+    $_setString(9, 12, v);
+  }
+
+  bool hasLogName() => $_has(9, 12);
+  void clearLogName() => clearField(12);
+
+  LogEntryOperation get operation => $_get(10, 15, null);
+  set operation(LogEntryOperation v) {
+    setField(15, v);
+  }
+
+  bool hasOperation() => $_has(10, 15);
+  void clearOperation() => clearField(15);
+
+  String get trace => $_get(11, 22, '');
+  set trace(String v) {
+    $_setString(11, 22, v);
+  }
+
+  bool hasTrace() => $_has(11, 22);
+  void clearTrace() => clearField(22);
+
+  LogEntrySourceLocation get sourceLocation => $_get(12, 23, null);
+  set sourceLocation(LogEntrySourceLocation v) {
+    setField(23, v);
+  }
+
+  bool hasSourceLocation() => $_has(12, 23);
+  void clearSourceLocation() => clearField(23);
+
+  $google$protobuf.Timestamp get receiveTimestamp => $_get(13, 24, null);
+  set receiveTimestamp($google$protobuf.Timestamp v) {
+    setField(24, v);
+  }
+
+  bool hasReceiveTimestamp() => $_has(13, 24);
+  void clearReceiveTimestamp() => clearField(24);
+}
+
+class _ReadonlyLogEntry extends LogEntry with ReadonlyMessageMixin {}
+
+class LogEntryOperation extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('LogEntryOperation')
+    ..a<String>(1, 'id', PbFieldType.OS)
+    ..a<String>(2, 'producer', PbFieldType.OS)
+    ..a<bool>(3, 'first', PbFieldType.OB)
+    ..a<bool>(4, 'last', PbFieldType.OB)
+    ..hasRequiredFields = false;
+
+  LogEntryOperation() : super();
+  LogEntryOperation.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  LogEntryOperation.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  LogEntryOperation clone() => new LogEntryOperation()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static LogEntryOperation create() => new LogEntryOperation();
+  static PbList<LogEntryOperation> createRepeated() =>
+      new PbList<LogEntryOperation>();
+  static LogEntryOperation getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyLogEntryOperation();
+    return _defaultInstance;
+  }
+
+  static LogEntryOperation _defaultInstance;
+  static void $checkItem(LogEntryOperation v) {
+    if (v is! LogEntryOperation) checkItemFailed(v, 'LogEntryOperation');
+  }
+
+  String get id => $_get(0, 1, '');
+  set id(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasId() => $_has(0, 1);
+  void clearId() => clearField(1);
+
+  String get producer => $_get(1, 2, '');
+  set producer(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasProducer() => $_has(1, 2);
+  void clearProducer() => clearField(2);
+
+  bool get first => $_get(2, 3, false);
+  set first(bool v) {
+    $_setBool(2, 3, v);
+  }
+
+  bool hasFirst() => $_has(2, 3);
+  void clearFirst() => clearField(3);
+
+  bool get last => $_get(3, 4, false);
+  set last(bool v) {
+    $_setBool(3, 4, v);
+  }
+
+  bool hasLast() => $_has(3, 4);
+  void clearLast() => clearField(4);
+}
+
+class _ReadonlyLogEntryOperation extends LogEntryOperation
+    with ReadonlyMessageMixin {}
+
+class LogEntrySourceLocation extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('LogEntrySourceLocation')
+    ..a<String>(1, 'file', PbFieldType.OS)
+    ..a<Int64>(2, 'line', PbFieldType.O6, Int64.ZERO)
+    ..a<String>(3, 'function', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  LogEntrySourceLocation() : super();
+  LogEntrySourceLocation.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  LogEntrySourceLocation.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  LogEntrySourceLocation clone() =>
+      new LogEntrySourceLocation()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static LogEntrySourceLocation create() => new LogEntrySourceLocation();
+  static PbList<LogEntrySourceLocation> createRepeated() =>
+      new PbList<LogEntrySourceLocation>();
+  static LogEntrySourceLocation getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyLogEntrySourceLocation();
+    return _defaultInstance;
+  }
+
+  static LogEntrySourceLocation _defaultInstance;
+  static void $checkItem(LogEntrySourceLocation v) {
+    if (v is! LogEntrySourceLocation)
+      checkItemFailed(v, 'LogEntrySourceLocation');
+  }
+
+  String get file => $_get(0, 1, '');
+  set file(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasFile() => $_has(0, 1);
+  void clearFile() => clearField(1);
+
+  Int64 get line => $_get(1, 2, null);
+  set line(Int64 v) {
+    $_setInt64(1, 2, v);
+  }
+
+  bool hasLine() => $_has(1, 2);
+  void clearLine() => clearField(2);
+
+  String get function => $_get(2, 3, '');
+  set function(String v) {
+    $_setString(2, 3, v);
+  }
+
+  bool hasFunction() => $_has(2, 3);
+  void clearFunction() => clearField(3);
+}
+
+class _ReadonlyLogEntrySourceLocation extends LogEntrySourceLocation
+    with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/logging/v2/log_entry.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/log_entry.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_log_entry_pbenum;

--- a/example/googleapis/lib/src/generated/google/logging/v2/log_entry.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/log_entry.pbjson.dart
@@ -1,0 +1,136 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_log_entry_pbjson;
+
+const LogEntry$json = const {
+  '1': 'LogEntry',
+  '2': const [
+    const {'1': 'log_name', '3': 12, '4': 1, '5': 9, '10': 'logName'},
+    const {
+      '1': 'resource',
+      '3': 8,
+      '4': 1,
+      '5': 11,
+      '6': '.google.api.MonitoredResource',
+      '10': 'resource'
+    },
+    const {
+      '1': 'proto_payload',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '9': 0,
+      '10': 'protoPayload'
+    },
+    const {
+      '1': 'text_payload',
+      '3': 3,
+      '4': 1,
+      '5': 9,
+      '9': 0,
+      '10': 'textPayload'
+    },
+    const {
+      '1': 'json_payload',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '9': 0,
+      '10': 'jsonPayload'
+    },
+    const {
+      '1': 'timestamp',
+      '3': 9,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'timestamp'
+    },
+    const {
+      '1': 'receive_timestamp',
+      '3': 24,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'receiveTimestamp'
+    },
+    const {
+      '1': 'severity',
+      '3': 10,
+      '4': 1,
+      '5': 14,
+      '6': '.google.logging.type.LogSeverity',
+      '10': 'severity'
+    },
+    const {'1': 'insert_id', '3': 4, '4': 1, '5': 9, '10': 'insertId'},
+    const {
+      '1': 'http_request',
+      '3': 7,
+      '4': 1,
+      '5': 11,
+      '6': '.google.logging.type.HttpRequest',
+      '10': 'httpRequest'
+    },
+    const {
+      '1': 'labels',
+      '3': 11,
+      '4': 3,
+      '5': 11,
+      '6': '.google.logging.v2.LogEntry.LabelsEntry',
+      '10': 'labels'
+    },
+    const {
+      '1': 'operation',
+      '3': 15,
+      '4': 1,
+      '5': 11,
+      '6': '.google.logging.v2.LogEntryOperation',
+      '10': 'operation'
+    },
+    const {'1': 'trace', '3': 22, '4': 1, '5': 9, '10': 'trace'},
+    const {
+      '1': 'source_location',
+      '3': 23,
+      '4': 1,
+      '5': 11,
+      '6': '.google.logging.v2.LogEntrySourceLocation',
+      '10': 'sourceLocation'
+    },
+  ],
+  '3': const [LogEntry_LabelsEntry$json],
+  '8': const [
+    const {'1': 'payload'},
+  ],
+};
+
+const LogEntry_LabelsEntry$json = const {
+  '1': 'LabelsEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  ],
+  '7': const {'7': true},
+};
+
+const LogEntryOperation$json = const {
+  '1': 'LogEntryOperation',
+  '2': const [
+    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    const {'1': 'producer', '3': 2, '4': 1, '5': 9, '10': 'producer'},
+    const {'1': 'first', '3': 3, '4': 1, '5': 8, '10': 'first'},
+    const {'1': 'last', '3': 4, '4': 1, '5': 8, '10': 'last'},
+  ],
+};
+
+const LogEntrySourceLocation$json = const {
+  '1': 'LogEntrySourceLocation',
+  '2': const [
+    const {'1': 'file', '3': 1, '4': 1, '5': 9, '10': 'file'},
+    const {'1': 'line', '3': 2, '4': 1, '5': 3, '10': 'line'},
+    const {'1': 'function', '3': 3, '4': 1, '5': 9, '10': 'function'},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/logging/v2/logging.pb.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/logging.pb.dart
@@ -1,0 +1,649 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_logging;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+import '../../api/monitored_resource.pb.dart' as $google$api;
+import 'log_entry.pb.dart';
+import '../../rpc/status.pb.dart' as $google$rpc;
+
+class DeleteLogRequest extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('DeleteLogRequest')
+    ..a<String>(1, 'logName', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  DeleteLogRequest() : super();
+  DeleteLogRequest.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  DeleteLogRequest.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  DeleteLogRequest clone() => new DeleteLogRequest()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static DeleteLogRequest create() => new DeleteLogRequest();
+  static PbList<DeleteLogRequest> createRepeated() =>
+      new PbList<DeleteLogRequest>();
+  static DeleteLogRequest getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyDeleteLogRequest();
+    return _defaultInstance;
+  }
+
+  static DeleteLogRequest _defaultInstance;
+  static void $checkItem(DeleteLogRequest v) {
+    if (v is! DeleteLogRequest) checkItemFailed(v, 'DeleteLogRequest');
+  }
+
+  String get logName => $_get(0, 1, '');
+  set logName(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasLogName() => $_has(0, 1);
+  void clearLogName() => clearField(1);
+}
+
+class _ReadonlyDeleteLogRequest extends DeleteLogRequest
+    with ReadonlyMessageMixin {}
+
+class WriteLogEntriesRequest_LabelsEntry extends GeneratedMessage {
+  static final BuilderInfo _i =
+      new BuilderInfo('WriteLogEntriesRequest_LabelsEntry')
+        ..a<String>(1, 'key', PbFieldType.OS)
+        ..a<String>(2, 'value', PbFieldType.OS)
+        ..hasRequiredFields = false;
+
+  WriteLogEntriesRequest_LabelsEntry() : super();
+  WriteLogEntriesRequest_LabelsEntry.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  WriteLogEntriesRequest_LabelsEntry.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  WriteLogEntriesRequest_LabelsEntry clone() =>
+      new WriteLogEntriesRequest_LabelsEntry()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static WriteLogEntriesRequest_LabelsEntry create() =>
+      new WriteLogEntriesRequest_LabelsEntry();
+  static PbList<WriteLogEntriesRequest_LabelsEntry> createRepeated() =>
+      new PbList<WriteLogEntriesRequest_LabelsEntry>();
+  static WriteLogEntriesRequest_LabelsEntry getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyWriteLogEntriesRequest_LabelsEntry();
+    return _defaultInstance;
+  }
+
+  static WriteLogEntriesRequest_LabelsEntry _defaultInstance;
+  static void $checkItem(WriteLogEntriesRequest_LabelsEntry v) {
+    if (v is! WriteLogEntriesRequest_LabelsEntry)
+      checkItemFailed(v, 'WriteLogEntriesRequest_LabelsEntry');
+  }
+
+  String get key => $_get(0, 1, '');
+  set key(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasKey() => $_has(0, 1);
+  void clearKey() => clearField(1);
+
+  String get value => $_get(1, 2, '');
+  set value(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasValue() => $_has(1, 2);
+  void clearValue() => clearField(2);
+}
+
+class _ReadonlyWriteLogEntriesRequest_LabelsEntry
+    extends WriteLogEntriesRequest_LabelsEntry with ReadonlyMessageMixin {}
+
+class WriteLogEntriesRequest extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('WriteLogEntriesRequest')
+    ..a<String>(1, 'logName', PbFieldType.OS)
+    ..a<$google$api.MonitoredResource>(
+        2,
+        'resource',
+        PbFieldType.OM,
+        $google$api.MonitoredResource.getDefault,
+        $google$api.MonitoredResource.create)
+    ..pp<WriteLogEntriesRequest_LabelsEntry>(
+        3,
+        'labels',
+        PbFieldType.PM,
+        WriteLogEntriesRequest_LabelsEntry.$checkItem,
+        WriteLogEntriesRequest_LabelsEntry.create)
+    ..pp<LogEntry>(
+        4, 'entries', PbFieldType.PM, LogEntry.$checkItem, LogEntry.create)
+    ..a<bool>(5, 'partialSuccess', PbFieldType.OB)
+    ..hasRequiredFields = false;
+
+  WriteLogEntriesRequest() : super();
+  WriteLogEntriesRequest.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  WriteLogEntriesRequest.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  WriteLogEntriesRequest clone() =>
+      new WriteLogEntriesRequest()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static WriteLogEntriesRequest create() => new WriteLogEntriesRequest();
+  static PbList<WriteLogEntriesRequest> createRepeated() =>
+      new PbList<WriteLogEntriesRequest>();
+  static WriteLogEntriesRequest getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyWriteLogEntriesRequest();
+    return _defaultInstance;
+  }
+
+  static WriteLogEntriesRequest _defaultInstance;
+  static void $checkItem(WriteLogEntriesRequest v) {
+    if (v is! WriteLogEntriesRequest)
+      checkItemFailed(v, 'WriteLogEntriesRequest');
+  }
+
+  String get logName => $_get(0, 1, '');
+  set logName(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasLogName() => $_has(0, 1);
+  void clearLogName() => clearField(1);
+
+  $google$api.MonitoredResource get resource => $_get(1, 2, null);
+  set resource($google$api.MonitoredResource v) {
+    setField(2, v);
+  }
+
+  bool hasResource() => $_has(1, 2);
+  void clearResource() => clearField(2);
+
+  List<WriteLogEntriesRequest_LabelsEntry> get labels => $_get(2, 3, null);
+
+  List<LogEntry> get entries => $_get(3, 4, null);
+
+  bool get partialSuccess => $_get(4, 5, false);
+  set partialSuccess(bool v) {
+    $_setBool(4, 5, v);
+  }
+
+  bool hasPartialSuccess() => $_has(4, 5);
+  void clearPartialSuccess() => clearField(5);
+}
+
+class _ReadonlyWriteLogEntriesRequest extends WriteLogEntriesRequest
+    with ReadonlyMessageMixin {}
+
+class WriteLogEntriesResponse extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('WriteLogEntriesResponse')
+    ..hasRequiredFields = false;
+
+  WriteLogEntriesResponse() : super();
+  WriteLogEntriesResponse.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  WriteLogEntriesResponse.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  WriteLogEntriesResponse clone() =>
+      new WriteLogEntriesResponse()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static WriteLogEntriesResponse create() => new WriteLogEntriesResponse();
+  static PbList<WriteLogEntriesResponse> createRepeated() =>
+      new PbList<WriteLogEntriesResponse>();
+  static WriteLogEntriesResponse getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyWriteLogEntriesResponse();
+    return _defaultInstance;
+  }
+
+  static WriteLogEntriesResponse _defaultInstance;
+  static void $checkItem(WriteLogEntriesResponse v) {
+    if (v is! WriteLogEntriesResponse)
+      checkItemFailed(v, 'WriteLogEntriesResponse');
+  }
+}
+
+class _ReadonlyWriteLogEntriesResponse extends WriteLogEntriesResponse
+    with ReadonlyMessageMixin {}
+
+class WriteLogEntriesPartialErrors_LogEntryErrorsEntry
+    extends GeneratedMessage {
+  static final BuilderInfo _i =
+      new BuilderInfo('WriteLogEntriesPartialErrors_LogEntryErrorsEntry')
+        ..a<int>(1, 'key', PbFieldType.O3)
+        ..a<$google$rpc.Status>(2, 'value', PbFieldType.OM,
+            $google$rpc.Status.getDefault, $google$rpc.Status.create)
+        ..hasRequiredFields = false;
+
+  WriteLogEntriesPartialErrors_LogEntryErrorsEntry() : super();
+  WriteLogEntriesPartialErrors_LogEntryErrorsEntry.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  WriteLogEntriesPartialErrors_LogEntryErrorsEntry.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  WriteLogEntriesPartialErrors_LogEntryErrorsEntry clone() =>
+      new WriteLogEntriesPartialErrors_LogEntryErrorsEntry()
+        ..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static WriteLogEntriesPartialErrors_LogEntryErrorsEntry create() =>
+      new WriteLogEntriesPartialErrors_LogEntryErrorsEntry();
+  static PbList<WriteLogEntriesPartialErrors_LogEntryErrorsEntry>
+      createRepeated() =>
+          new PbList<WriteLogEntriesPartialErrors_LogEntryErrorsEntry>();
+  static WriteLogEntriesPartialErrors_LogEntryErrorsEntry getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance =
+          new _ReadonlyWriteLogEntriesPartialErrors_LogEntryErrorsEntry();
+    return _defaultInstance;
+  }
+
+  static WriteLogEntriesPartialErrors_LogEntryErrorsEntry _defaultInstance;
+  static void $checkItem(WriteLogEntriesPartialErrors_LogEntryErrorsEntry v) {
+    if (v is! WriteLogEntriesPartialErrors_LogEntryErrorsEntry)
+      checkItemFailed(v, 'WriteLogEntriesPartialErrors_LogEntryErrorsEntry');
+  }
+
+  int get key => $_get(0, 1, 0);
+  set key(int v) {
+    $_setUnsignedInt32(0, 1, v);
+  }
+
+  bool hasKey() => $_has(0, 1);
+  void clearKey() => clearField(1);
+
+  $google$rpc.Status get value => $_get(1, 2, null);
+  set value($google$rpc.Status v) {
+    setField(2, v);
+  }
+
+  bool hasValue() => $_has(1, 2);
+  void clearValue() => clearField(2);
+}
+
+class _ReadonlyWriteLogEntriesPartialErrors_LogEntryErrorsEntry
+    extends WriteLogEntriesPartialErrors_LogEntryErrorsEntry
+    with ReadonlyMessageMixin {}
+
+class WriteLogEntriesPartialErrors extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('WriteLogEntriesPartialErrors')
+    ..pp<WriteLogEntriesPartialErrors_LogEntryErrorsEntry>(
+        1,
+        'logEntryErrors',
+        PbFieldType.PM,
+        WriteLogEntriesPartialErrors_LogEntryErrorsEntry.$checkItem,
+        WriteLogEntriesPartialErrors_LogEntryErrorsEntry.create)
+    ..hasRequiredFields = false;
+
+  WriteLogEntriesPartialErrors() : super();
+  WriteLogEntriesPartialErrors.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  WriteLogEntriesPartialErrors.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  WriteLogEntriesPartialErrors clone() =>
+      new WriteLogEntriesPartialErrors()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static WriteLogEntriesPartialErrors create() =>
+      new WriteLogEntriesPartialErrors();
+  static PbList<WriteLogEntriesPartialErrors> createRepeated() =>
+      new PbList<WriteLogEntriesPartialErrors>();
+  static WriteLogEntriesPartialErrors getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyWriteLogEntriesPartialErrors();
+    return _defaultInstance;
+  }
+
+  static WriteLogEntriesPartialErrors _defaultInstance;
+  static void $checkItem(WriteLogEntriesPartialErrors v) {
+    if (v is! WriteLogEntriesPartialErrors)
+      checkItemFailed(v, 'WriteLogEntriesPartialErrors');
+  }
+
+  List<WriteLogEntriesPartialErrors_LogEntryErrorsEntry> get logEntryErrors =>
+      $_get(0, 1, null);
+}
+
+class _ReadonlyWriteLogEntriesPartialErrors extends WriteLogEntriesPartialErrors
+    with ReadonlyMessageMixin {}
+
+class ListLogEntriesRequest extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('ListLogEntriesRequest')
+    ..p<String>(1, 'projectIds', PbFieldType.PS)
+    ..a<String>(2, 'filter', PbFieldType.OS)
+    ..a<String>(3, 'orderBy', PbFieldType.OS)
+    ..a<int>(4, 'pageSize', PbFieldType.O3)
+    ..a<String>(5, 'pageToken', PbFieldType.OS)
+    ..p<String>(8, 'resourceNames', PbFieldType.PS)
+    ..hasRequiredFields = false;
+
+  ListLogEntriesRequest() : super();
+  ListLogEntriesRequest.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListLogEntriesRequest.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListLogEntriesRequest clone() =>
+      new ListLogEntriesRequest()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListLogEntriesRequest create() => new ListLogEntriesRequest();
+  static PbList<ListLogEntriesRequest> createRepeated() =>
+      new PbList<ListLogEntriesRequest>();
+  static ListLogEntriesRequest getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyListLogEntriesRequest();
+    return _defaultInstance;
+  }
+
+  static ListLogEntriesRequest _defaultInstance;
+  static void $checkItem(ListLogEntriesRequest v) {
+    if (v is! ListLogEntriesRequest)
+      checkItemFailed(v, 'ListLogEntriesRequest');
+  }
+
+  List<String> get projectIds => $_get(0, 1, null);
+
+  String get filter => $_get(1, 2, '');
+  set filter(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasFilter() => $_has(1, 2);
+  void clearFilter() => clearField(2);
+
+  String get orderBy => $_get(2, 3, '');
+  set orderBy(String v) {
+    $_setString(2, 3, v);
+  }
+
+  bool hasOrderBy() => $_has(2, 3);
+  void clearOrderBy() => clearField(3);
+
+  int get pageSize => $_get(3, 4, 0);
+  set pageSize(int v) {
+    $_setUnsignedInt32(3, 4, v);
+  }
+
+  bool hasPageSize() => $_has(3, 4);
+  void clearPageSize() => clearField(4);
+
+  String get pageToken => $_get(4, 5, '');
+  set pageToken(String v) {
+    $_setString(4, 5, v);
+  }
+
+  bool hasPageToken() => $_has(4, 5);
+  void clearPageToken() => clearField(5);
+
+  List<String> get resourceNames => $_get(5, 8, null);
+}
+
+class _ReadonlyListLogEntriesRequest extends ListLogEntriesRequest
+    with ReadonlyMessageMixin {}
+
+class ListLogEntriesResponse extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('ListLogEntriesResponse')
+    ..pp<LogEntry>(
+        1, 'entries', PbFieldType.PM, LogEntry.$checkItem, LogEntry.create)
+    ..a<String>(2, 'nextPageToken', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  ListLogEntriesResponse() : super();
+  ListLogEntriesResponse.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListLogEntriesResponse.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListLogEntriesResponse clone() =>
+      new ListLogEntriesResponse()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListLogEntriesResponse create() => new ListLogEntriesResponse();
+  static PbList<ListLogEntriesResponse> createRepeated() =>
+      new PbList<ListLogEntriesResponse>();
+  static ListLogEntriesResponse getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyListLogEntriesResponse();
+    return _defaultInstance;
+  }
+
+  static ListLogEntriesResponse _defaultInstance;
+  static void $checkItem(ListLogEntriesResponse v) {
+    if (v is! ListLogEntriesResponse)
+      checkItemFailed(v, 'ListLogEntriesResponse');
+  }
+
+  List<LogEntry> get entries => $_get(0, 1, null);
+
+  String get nextPageToken => $_get(1, 2, '');
+  set nextPageToken(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasNextPageToken() => $_has(1, 2);
+  void clearNextPageToken() => clearField(2);
+}
+
+class _ReadonlyListLogEntriesResponse extends ListLogEntriesResponse
+    with ReadonlyMessageMixin {}
+
+class ListMonitoredResourceDescriptorsRequest extends GeneratedMessage {
+  static final BuilderInfo _i =
+      new BuilderInfo('ListMonitoredResourceDescriptorsRequest')
+        ..a<int>(1, 'pageSize', PbFieldType.O3)
+        ..a<String>(2, 'pageToken', PbFieldType.OS)
+        ..hasRequiredFields = false;
+
+  ListMonitoredResourceDescriptorsRequest() : super();
+  ListMonitoredResourceDescriptorsRequest.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListMonitoredResourceDescriptorsRequest.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListMonitoredResourceDescriptorsRequest clone() =>
+      new ListMonitoredResourceDescriptorsRequest()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListMonitoredResourceDescriptorsRequest create() =>
+      new ListMonitoredResourceDescriptorsRequest();
+  static PbList<ListMonitoredResourceDescriptorsRequest> createRepeated() =>
+      new PbList<ListMonitoredResourceDescriptorsRequest>();
+  static ListMonitoredResourceDescriptorsRequest getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyListMonitoredResourceDescriptorsRequest();
+    return _defaultInstance;
+  }
+
+  static ListMonitoredResourceDescriptorsRequest _defaultInstance;
+  static void $checkItem(ListMonitoredResourceDescriptorsRequest v) {
+    if (v is! ListMonitoredResourceDescriptorsRequest)
+      checkItemFailed(v, 'ListMonitoredResourceDescriptorsRequest');
+  }
+
+  int get pageSize => $_get(0, 1, 0);
+  set pageSize(int v) {
+    $_setUnsignedInt32(0, 1, v);
+  }
+
+  bool hasPageSize() => $_has(0, 1);
+  void clearPageSize() => clearField(1);
+
+  String get pageToken => $_get(1, 2, '');
+  set pageToken(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasPageToken() => $_has(1, 2);
+  void clearPageToken() => clearField(2);
+}
+
+class _ReadonlyListMonitoredResourceDescriptorsRequest
+    extends ListMonitoredResourceDescriptorsRequest with ReadonlyMessageMixin {}
+
+class ListMonitoredResourceDescriptorsResponse extends GeneratedMessage {
+  static final BuilderInfo _i =
+      new BuilderInfo('ListMonitoredResourceDescriptorsResponse')
+        ..pp<$google$api.MonitoredResourceDescriptor>(
+            1,
+            'resourceDescriptors',
+            PbFieldType.PM,
+            $google$api.MonitoredResourceDescriptor.$checkItem,
+            $google$api.MonitoredResourceDescriptor.create)
+        ..a<String>(2, 'nextPageToken', PbFieldType.OS)
+        ..hasRequiredFields = false;
+
+  ListMonitoredResourceDescriptorsResponse() : super();
+  ListMonitoredResourceDescriptorsResponse.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListMonitoredResourceDescriptorsResponse.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListMonitoredResourceDescriptorsResponse clone() =>
+      new ListMonitoredResourceDescriptorsResponse()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListMonitoredResourceDescriptorsResponse create() =>
+      new ListMonitoredResourceDescriptorsResponse();
+  static PbList<ListMonitoredResourceDescriptorsResponse> createRepeated() =>
+      new PbList<ListMonitoredResourceDescriptorsResponse>();
+  static ListMonitoredResourceDescriptorsResponse getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance =
+          new _ReadonlyListMonitoredResourceDescriptorsResponse();
+    return _defaultInstance;
+  }
+
+  static ListMonitoredResourceDescriptorsResponse _defaultInstance;
+  static void $checkItem(ListMonitoredResourceDescriptorsResponse v) {
+    if (v is! ListMonitoredResourceDescriptorsResponse)
+      checkItemFailed(v, 'ListMonitoredResourceDescriptorsResponse');
+  }
+
+  List<$google$api.MonitoredResourceDescriptor> get resourceDescriptors =>
+      $_get(0, 1, null);
+
+  String get nextPageToken => $_get(1, 2, '');
+  set nextPageToken(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasNextPageToken() => $_has(1, 2);
+  void clearNextPageToken() => clearField(2);
+}
+
+class _ReadonlyListMonitoredResourceDescriptorsResponse
+    extends ListMonitoredResourceDescriptorsResponse with ReadonlyMessageMixin {
+}
+
+class ListLogsRequest extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('ListLogsRequest')
+    ..a<String>(1, 'parent', PbFieldType.OS)
+    ..a<int>(2, 'pageSize', PbFieldType.O3)
+    ..a<String>(3, 'pageToken', PbFieldType.OS)
+    ..hasRequiredFields = false;
+
+  ListLogsRequest() : super();
+  ListLogsRequest.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListLogsRequest.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListLogsRequest clone() => new ListLogsRequest()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListLogsRequest create() => new ListLogsRequest();
+  static PbList<ListLogsRequest> createRepeated() =>
+      new PbList<ListLogsRequest>();
+  static ListLogsRequest getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyListLogsRequest();
+    return _defaultInstance;
+  }
+
+  static ListLogsRequest _defaultInstance;
+  static void $checkItem(ListLogsRequest v) {
+    if (v is! ListLogsRequest) checkItemFailed(v, 'ListLogsRequest');
+  }
+
+  String get parent => $_get(0, 1, '');
+  set parent(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasParent() => $_has(0, 1);
+  void clearParent() => clearField(1);
+
+  int get pageSize => $_get(1, 2, 0);
+  set pageSize(int v) {
+    $_setUnsignedInt32(1, 2, v);
+  }
+
+  bool hasPageSize() => $_has(1, 2);
+  void clearPageSize() => clearField(2);
+
+  String get pageToken => $_get(2, 3, '');
+  set pageToken(String v) {
+    $_setString(2, 3, v);
+  }
+
+  bool hasPageToken() => $_has(2, 3);
+  void clearPageToken() => clearField(3);
+}
+
+class _ReadonlyListLogsRequest extends ListLogsRequest
+    with ReadonlyMessageMixin {}
+
+class ListLogsResponse extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('ListLogsResponse')
+    ..a<String>(2, 'nextPageToken', PbFieldType.OS)
+    ..p<String>(3, 'logNames', PbFieldType.PS)
+    ..hasRequiredFields = false;
+
+  ListLogsResponse() : super();
+  ListLogsResponse.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListLogsResponse.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListLogsResponse clone() => new ListLogsResponse()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListLogsResponse create() => new ListLogsResponse();
+  static PbList<ListLogsResponse> createRepeated() =>
+      new PbList<ListLogsResponse>();
+  static ListLogsResponse getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyListLogsResponse();
+    return _defaultInstance;
+  }
+
+  static ListLogsResponse _defaultInstance;
+  static void $checkItem(ListLogsResponse v) {
+    if (v is! ListLogsResponse) checkItemFailed(v, 'ListLogsResponse');
+  }
+
+  String get nextPageToken => $_get(0, 2, '');
+  set nextPageToken(String v) {
+    $_setString(0, 2, v);
+  }
+
+  bool hasNextPageToken() => $_has(0, 2);
+  void clearNextPageToken() => clearField(2);
+
+  List<String> get logNames => $_get(1, 3, null);
+}
+
+class _ReadonlyListLogsResponse extends ListLogsResponse
+    with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/logging/v2/logging.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/logging.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_logging_pbenum;

--- a/example/googleapis/lib/src/generated/google/logging/v2/logging.pbgrpc.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/logging.pbgrpc.dart
@@ -1,0 +1,168 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_logging_pbgrpc;
+
+import 'dart:async';
+
+import 'package:grpc/grpc.dart';
+
+import 'logging.pb.dart';
+import '../../protobuf/empty.pb.dart' as $google$protobuf;
+export 'logging.pb.dart';
+
+class LoggingServiceV2Client extends Client {
+  static final _$deleteLog =
+      new ClientMethod<DeleteLogRequest, $google$protobuf.Empty>(
+          '/google.logging.v2.LoggingServiceV2/DeleteLog',
+          (DeleteLogRequest value) => value.writeToBuffer(),
+          (List<int> value) => new $google$protobuf.Empty.fromBuffer(value));
+  static final _$writeLogEntries =
+      new ClientMethod<WriteLogEntriesRequest, WriteLogEntriesResponse>(
+          '/google.logging.v2.LoggingServiceV2/WriteLogEntries',
+          (WriteLogEntriesRequest value) => value.writeToBuffer(),
+          (List<int> value) => new WriteLogEntriesResponse.fromBuffer(value));
+  static final _$listLogEntries =
+      new ClientMethod<ListLogEntriesRequest, ListLogEntriesResponse>(
+          '/google.logging.v2.LoggingServiceV2/ListLogEntries',
+          (ListLogEntriesRequest value) => value.writeToBuffer(),
+          (List<int> value) => new ListLogEntriesResponse.fromBuffer(value));
+  static final _$listMonitoredResourceDescriptors = new ClientMethod<
+          ListMonitoredResourceDescriptorsRequest,
+          ListMonitoredResourceDescriptorsResponse>(
+      '/google.logging.v2.LoggingServiceV2/ListMonitoredResourceDescriptors',
+      (ListMonitoredResourceDescriptorsRequest value) => value.writeToBuffer(),
+      (List<int> value) =>
+          new ListMonitoredResourceDescriptorsResponse.fromBuffer(value));
+  static final _$listLogs = new ClientMethod<ListLogsRequest, ListLogsResponse>(
+      '/google.logging.v2.LoggingServiceV2/ListLogs',
+      (ListLogsRequest value) => value.writeToBuffer(),
+      (List<int> value) => new ListLogsResponse.fromBuffer(value));
+
+  LoggingServiceV2Client(ClientChannel channel, {CallOptions options})
+      : super(channel, options: options);
+
+  ResponseFuture<$google$protobuf.Empty> deleteLog(DeleteLogRequest request,
+      {CallOptions options}) {
+    final call = $createCall(_$deleteLog, new Stream.fromIterable([request]),
+        options: options);
+    return new ResponseFuture(call);
+  }
+
+  ResponseFuture<WriteLogEntriesResponse> writeLogEntries(
+      WriteLogEntriesRequest request,
+      {CallOptions options}) {
+    final call = $createCall(
+        _$writeLogEntries, new Stream.fromIterable([request]),
+        options: options);
+    return new ResponseFuture(call);
+  }
+
+  ResponseFuture<ListLogEntriesResponse> listLogEntries(
+      ListLogEntriesRequest request,
+      {CallOptions options}) {
+    final call = $createCall(
+        _$listLogEntries, new Stream.fromIterable([request]),
+        options: options);
+    return new ResponseFuture(call);
+  }
+
+  ResponseFuture<ListMonitoredResourceDescriptorsResponse>
+      listMonitoredResourceDescriptors(
+          ListMonitoredResourceDescriptorsRequest request,
+          {CallOptions options}) {
+    final call = $createCall(
+        _$listMonitoredResourceDescriptors, new Stream.fromIterable([request]),
+        options: options);
+    return new ResponseFuture(call);
+  }
+
+  ResponseFuture<ListLogsResponse> listLogs(ListLogsRequest request,
+      {CallOptions options}) {
+    final call = $createCall(_$listLogs, new Stream.fromIterable([request]),
+        options: options);
+    return new ResponseFuture(call);
+  }
+}
+
+abstract class LoggingServiceV2ServiceBase extends Service {
+  String get $name => 'google.logging.v2.LoggingServiceV2';
+
+  LoggingServiceV2ServiceBase() {
+    $addMethod(new ServiceMethod(
+        'DeleteLog',
+        deleteLog_Pre,
+        false,
+        false,
+        (List<int> value) => new DeleteLogRequest.fromBuffer(value),
+        ($google$protobuf.Empty value) => value.writeToBuffer()));
+    $addMethod(new ServiceMethod(
+        'WriteLogEntries',
+        writeLogEntries_Pre,
+        false,
+        false,
+        (List<int> value) => new WriteLogEntriesRequest.fromBuffer(value),
+        (WriteLogEntriesResponse value) => value.writeToBuffer()));
+    $addMethod(new ServiceMethod(
+        'ListLogEntries',
+        listLogEntries_Pre,
+        false,
+        false,
+        (List<int> value) => new ListLogEntriesRequest.fromBuffer(value),
+        (ListLogEntriesResponse value) => value.writeToBuffer()));
+    $addMethod(new ServiceMethod(
+        'ListMonitoredResourceDescriptors',
+        listMonitoredResourceDescriptors_Pre,
+        false,
+        false,
+        (List<int> value) =>
+            new ListMonitoredResourceDescriptorsRequest.fromBuffer(value),
+        (ListMonitoredResourceDescriptorsResponse value) =>
+            value.writeToBuffer()));
+    $addMethod(new ServiceMethod(
+        'ListLogs',
+        listLogs_Pre,
+        false,
+        false,
+        (List<int> value) => new ListLogsRequest.fromBuffer(value),
+        (ListLogsResponse value) => value.writeToBuffer()));
+  }
+
+  Future<$google$protobuf.Empty> deleteLog_Pre(
+      ServiceCall call, Future<DeleteLogRequest> request) async {
+    return deleteLog(call, await request);
+  }
+
+  Future<WriteLogEntriesResponse> writeLogEntries_Pre(
+      ServiceCall call, Future<WriteLogEntriesRequest> request) async {
+    return writeLogEntries(call, await request);
+  }
+
+  Future<ListLogEntriesResponse> listLogEntries_Pre(
+      ServiceCall call, Future<ListLogEntriesRequest> request) async {
+    return listLogEntries(call, await request);
+  }
+
+  Future<ListMonitoredResourceDescriptorsResponse>
+      listMonitoredResourceDescriptors_Pre(ServiceCall call,
+          Future<ListMonitoredResourceDescriptorsRequest> request) async {
+    return listMonitoredResourceDescriptors(call, await request);
+  }
+
+  Future<ListLogsResponse> listLogs_Pre(
+      ServiceCall call, Future<ListLogsRequest> request) async {
+    return listLogs(call, await request);
+  }
+
+  Future<$google$protobuf.Empty> deleteLog(
+      ServiceCall call, DeleteLogRequest request);
+  Future<WriteLogEntriesResponse> writeLogEntries(
+      ServiceCall call, WriteLogEntriesRequest request);
+  Future<ListLogEntriesResponse> listLogEntries(
+      ServiceCall call, ListLogEntriesRequest request);
+  Future<ListMonitoredResourceDescriptorsResponse>
+      listMonitoredResourceDescriptors(
+          ServiceCall call, ListMonitoredResourceDescriptorsRequest request);
+  Future<ListLogsResponse> listLogs(ServiceCall call, ListLogsRequest request);
+}

--- a/example/googleapis/lib/src/generated/google/logging/v2/logging.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/logging/v2/logging.pbjson.dart
@@ -1,0 +1,187 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.logging.v2_logging_pbjson;
+
+const DeleteLogRequest$json = const {
+  '1': 'DeleteLogRequest',
+  '2': const [
+    const {'1': 'log_name', '3': 1, '4': 1, '5': 9, '10': 'logName'},
+  ],
+};
+
+const WriteLogEntriesRequest$json = const {
+  '1': 'WriteLogEntriesRequest',
+  '2': const [
+    const {'1': 'log_name', '3': 1, '4': 1, '5': 9, '10': 'logName'},
+    const {
+      '1': 'resource',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.api.MonitoredResource',
+      '10': 'resource'
+    },
+    const {
+      '1': 'labels',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.google.logging.v2.WriteLogEntriesRequest.LabelsEntry',
+      '10': 'labels'
+    },
+    const {
+      '1': 'entries',
+      '3': 4,
+      '4': 3,
+      '5': 11,
+      '6': '.google.logging.v2.LogEntry',
+      '10': 'entries'
+    },
+    const {
+      '1': 'partial_success',
+      '3': 5,
+      '4': 1,
+      '5': 8,
+      '10': 'partialSuccess'
+    },
+  ],
+  '3': const [WriteLogEntriesRequest_LabelsEntry$json],
+};
+
+const WriteLogEntriesRequest_LabelsEntry$json = const {
+  '1': 'LabelsEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  ],
+  '7': const {'7': true},
+};
+
+const WriteLogEntriesResponse$json = const {
+  '1': 'WriteLogEntriesResponse',
+};
+
+const WriteLogEntriesPartialErrors$json = const {
+  '1': 'WriteLogEntriesPartialErrors',
+  '2': const [
+    const {
+      '1': 'log_entry_errors',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6':
+          '.google.logging.v2.WriteLogEntriesPartialErrors.LogEntryErrorsEntry',
+      '10': 'logEntryErrors'
+    },
+  ],
+  '3': const [WriteLogEntriesPartialErrors_LogEntryErrorsEntry$json],
+};
+
+const WriteLogEntriesPartialErrors_LogEntryErrorsEntry$json = const {
+  '1': 'LogEntryErrorsEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 5, '10': 'key'},
+    const {
+      '1': 'value',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.rpc.Status',
+      '10': 'value'
+    },
+  ],
+  '7': const {'7': true},
+};
+
+const ListLogEntriesRequest$json = const {
+  '1': 'ListLogEntriesRequest',
+  '2': const [
+    const {'1': 'project_ids', '3': 1, '4': 3, '5': 9, '10': 'projectIds'},
+    const {
+      '1': 'resource_names',
+      '3': 8,
+      '4': 3,
+      '5': 9,
+      '10': 'resourceNames'
+    },
+    const {'1': 'filter', '3': 2, '4': 1, '5': 9, '10': 'filter'},
+    const {'1': 'order_by', '3': 3, '4': 1, '5': 9, '10': 'orderBy'},
+    const {'1': 'page_size', '3': 4, '4': 1, '5': 5, '10': 'pageSize'},
+    const {'1': 'page_token', '3': 5, '4': 1, '5': 9, '10': 'pageToken'},
+  ],
+};
+
+const ListLogEntriesResponse$json = const {
+  '1': 'ListLogEntriesResponse',
+  '2': const [
+    const {
+      '1': 'entries',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.logging.v2.LogEntry',
+      '10': 'entries'
+    },
+    const {
+      '1': 'next_page_token',
+      '3': 2,
+      '4': 1,
+      '5': 9,
+      '10': 'nextPageToken'
+    },
+  ],
+};
+
+const ListMonitoredResourceDescriptorsRequest$json = const {
+  '1': 'ListMonitoredResourceDescriptorsRequest',
+  '2': const [
+    const {'1': 'page_size', '3': 1, '4': 1, '5': 5, '10': 'pageSize'},
+    const {'1': 'page_token', '3': 2, '4': 1, '5': 9, '10': 'pageToken'},
+  ],
+};
+
+const ListMonitoredResourceDescriptorsResponse$json = const {
+  '1': 'ListMonitoredResourceDescriptorsResponse',
+  '2': const [
+    const {
+      '1': 'resource_descriptors',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.api.MonitoredResourceDescriptor',
+      '10': 'resourceDescriptors'
+    },
+    const {
+      '1': 'next_page_token',
+      '3': 2,
+      '4': 1,
+      '5': 9,
+      '10': 'nextPageToken'
+    },
+  ],
+};
+
+const ListLogsRequest$json = const {
+  '1': 'ListLogsRequest',
+  '2': const [
+    const {'1': 'parent', '3': 1, '4': 1, '5': 9, '10': 'parent'},
+    const {'1': 'page_size', '3': 2, '4': 1, '5': 5, '10': 'pageSize'},
+    const {'1': 'page_token', '3': 3, '4': 1, '5': 9, '10': 'pageToken'},
+  ],
+};
+
+const ListLogsResponse$json = const {
+  '1': 'ListLogsResponse',
+  '2': const [
+    const {'1': 'log_names', '3': 3, '4': 3, '5': 9, '10': 'logNames'},
+    const {
+      '1': 'next_page_token',
+      '3': 2,
+      '4': 1,
+      '5': 9,
+      '10': 'nextPageToken'
+    },
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/protobuf/any.pb.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/any.pb.dart
@@ -1,0 +1,54 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_any;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+class Any extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Any')
+    ..a<String>(1, 'typeUrl', PbFieldType.OS)
+    ..a<List<int>>(2, 'value', PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  Any() : super();
+  Any.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Any.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Any clone() => new Any()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Any create() => new Any();
+  static PbList<Any> createRepeated() => new PbList<Any>();
+  static Any getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyAny();
+    return _defaultInstance;
+  }
+
+  static Any _defaultInstance;
+  static void $checkItem(Any v) {
+    if (v is! Any) checkItemFailed(v, 'Any');
+  }
+
+  String get typeUrl => $_get(0, 1, '');
+  set typeUrl(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasTypeUrl() => $_has(0, 1);
+  void clearTypeUrl() => clearField(1);
+
+  List<int> get value => $_get(1, 2, null);
+  set value(List<int> v) {
+    $_setBytes(1, 2, v);
+  }
+
+  bool hasValue() => $_has(1, 2);
+  void clearValue() => clearField(2);
+}
+
+class _ReadonlyAny extends Any with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/protobuf/any.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/any.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_any_pbenum;

--- a/example/googleapis/lib/src/generated/google/protobuf/any.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/any.pbjson.dart
@@ -1,0 +1,13 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_any_pbjson;
+
+const Any$json = const {
+  '1': 'Any',
+  '2': const [
+    const {'1': 'type_url', '3': 1, '4': 1, '5': 9, '10': 'typeUrl'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 12, '10': 'value'},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/protobuf/duration.pb.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/duration.pb.dart
@@ -1,0 +1,56 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_duration;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:fixnum/fixnum.dart';
+import 'package:protobuf/protobuf.dart';
+
+class Duration extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Duration')
+    ..a<Int64>(1, 'seconds', PbFieldType.O6, Int64.ZERO)
+    ..a<int>(2, 'nanos', PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  Duration() : super();
+  Duration.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Duration.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Duration clone() => new Duration()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Duration create() => new Duration();
+  static PbList<Duration> createRepeated() => new PbList<Duration>();
+  static Duration getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyDuration();
+    return _defaultInstance;
+  }
+
+  static Duration _defaultInstance;
+  static void $checkItem(Duration v) {
+    if (v is! Duration) checkItemFailed(v, 'Duration');
+  }
+
+  Int64 get seconds => $_get(0, 1, null);
+  set seconds(Int64 v) {
+    $_setInt64(0, 1, v);
+  }
+
+  bool hasSeconds() => $_has(0, 1);
+  void clearSeconds() => clearField(1);
+
+  int get nanos => $_get(1, 2, 0);
+  set nanos(int v) {
+    $_setUnsignedInt32(1, 2, v);
+  }
+
+  bool hasNanos() => $_has(1, 2);
+  void clearNanos() => clearField(2);
+}
+
+class _ReadonlyDuration extends Duration with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/protobuf/duration.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/duration.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_duration_pbenum;

--- a/example/googleapis/lib/src/generated/google/protobuf/duration.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/duration.pbjson.dart
@@ -1,0 +1,13 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_duration_pbjson;
+
+const Duration$json = const {
+  '1': 'Duration',
+  '2': const [
+    const {'1': 'seconds', '3': 1, '4': 1, '5': 3, '10': 'seconds'},
+    const {'1': 'nanos', '3': 2, '4': 1, '5': 5, '10': 'nanos'},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/protobuf/empty.pb.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/empty.pb.dart
@@ -1,0 +1,36 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_empty;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+class Empty extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Empty')
+    ..hasRequiredFields = false;
+
+  Empty() : super();
+  Empty.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Empty.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Empty clone() => new Empty()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Empty create() => new Empty();
+  static PbList<Empty> createRepeated() => new PbList<Empty>();
+  static Empty getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyEmpty();
+    return _defaultInstance;
+  }
+
+  static Empty _defaultInstance;
+  static void $checkItem(Empty v) {
+    if (v is! Empty) checkItemFailed(v, 'Empty');
+  }
+}
+
+class _ReadonlyEmpty extends Empty with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/protobuf/empty.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/empty.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_empty_pbenum;

--- a/example/googleapis/lib/src/generated/google/protobuf/empty.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/empty.pbjson.dart
@@ -1,0 +1,9 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_empty_pbjson;
+
+const Empty$json = const {
+  '1': 'Empty',
+};

--- a/example/googleapis/lib/src/generated/google/protobuf/struct.pb.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/struct.pb.dart
@@ -1,0 +1,208 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_struct;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+import 'struct.pbenum.dart';
+
+export 'struct.pbenum.dart';
+
+class Struct_FieldsEntry extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Struct_FieldsEntry')
+    ..a<String>(1, 'key', PbFieldType.OS)
+    ..a<Value>(2, 'value', PbFieldType.OM, Value.getDefault, Value.create)
+    ..hasRequiredFields = false;
+
+  Struct_FieldsEntry() : super();
+  Struct_FieldsEntry.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Struct_FieldsEntry.fromJson(String i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Struct_FieldsEntry clone() =>
+      new Struct_FieldsEntry()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Struct_FieldsEntry create() => new Struct_FieldsEntry();
+  static PbList<Struct_FieldsEntry> createRepeated() =>
+      new PbList<Struct_FieldsEntry>();
+  static Struct_FieldsEntry getDefault() {
+    if (_defaultInstance == null)
+      _defaultInstance = new _ReadonlyStruct_FieldsEntry();
+    return _defaultInstance;
+  }
+
+  static Struct_FieldsEntry _defaultInstance;
+  static void $checkItem(Struct_FieldsEntry v) {
+    if (v is! Struct_FieldsEntry) checkItemFailed(v, 'Struct_FieldsEntry');
+  }
+
+  String get key => $_get(0, 1, '');
+  set key(String v) {
+    $_setString(0, 1, v);
+  }
+
+  bool hasKey() => $_has(0, 1);
+  void clearKey() => clearField(1);
+
+  Value get value => $_get(1, 2, null);
+  set value(Value v) {
+    setField(2, v);
+  }
+
+  bool hasValue() => $_has(1, 2);
+  void clearValue() => clearField(2);
+}
+
+class _ReadonlyStruct_FieldsEntry extends Struct_FieldsEntry
+    with ReadonlyMessageMixin {}
+
+class Struct extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Struct')
+    ..pp<Struct_FieldsEntry>(1, 'fields', PbFieldType.PM,
+        Struct_FieldsEntry.$checkItem, Struct_FieldsEntry.create)
+    ..hasRequiredFields = false;
+
+  Struct() : super();
+  Struct.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Struct.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Struct clone() => new Struct()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Struct create() => new Struct();
+  static PbList<Struct> createRepeated() => new PbList<Struct>();
+  static Struct getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyStruct();
+    return _defaultInstance;
+  }
+
+  static Struct _defaultInstance;
+  static void $checkItem(Struct v) {
+    if (v is! Struct) checkItemFailed(v, 'Struct');
+  }
+
+  List<Struct_FieldsEntry> get fields => $_get(0, 1, null);
+}
+
+class _ReadonlyStruct extends Struct with ReadonlyMessageMixin {}
+
+class Value extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Value')
+    ..e<NullValue>(1, 'nullValue', PbFieldType.OE, NullValue.NULL_VALUE,
+        NullValue.valueOf, NullValue.values)
+    ..a<double>(2, 'numberValue', PbFieldType.OD)
+    ..a<String>(3, 'stringValue', PbFieldType.OS)
+    ..a<bool>(4, 'boolValue', PbFieldType.OB)
+    ..a<Struct>(
+        5, 'structValue', PbFieldType.OM, Struct.getDefault, Struct.create)
+    ..a<ListValue>(
+        6, 'listValue', PbFieldType.OM, ListValue.getDefault, ListValue.create)
+    ..hasRequiredFields = false;
+
+  Value() : super();
+  Value.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Value.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Value clone() => new Value()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Value create() => new Value();
+  static PbList<Value> createRepeated() => new PbList<Value>();
+  static Value getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyValue();
+    return _defaultInstance;
+  }
+
+  static Value _defaultInstance;
+  static void $checkItem(Value v) {
+    if (v is! Value) checkItemFailed(v, 'Value');
+  }
+
+  NullValue get nullValue => $_get(0, 1, null);
+  set nullValue(NullValue v) {
+    setField(1, v);
+  }
+
+  bool hasNullValue() => $_has(0, 1);
+  void clearNullValue() => clearField(1);
+
+  double get numberValue => $_get(1, 2, null);
+  set numberValue(double v) {
+    $_setDouble(1, 2, v);
+  }
+
+  bool hasNumberValue() => $_has(1, 2);
+  void clearNumberValue() => clearField(2);
+
+  String get stringValue => $_get(2, 3, '');
+  set stringValue(String v) {
+    $_setString(2, 3, v);
+  }
+
+  bool hasStringValue() => $_has(2, 3);
+  void clearStringValue() => clearField(3);
+
+  bool get boolValue => $_get(3, 4, false);
+  set boolValue(bool v) {
+    $_setBool(3, 4, v);
+  }
+
+  bool hasBoolValue() => $_has(3, 4);
+  void clearBoolValue() => clearField(4);
+
+  Struct get structValue => $_get(4, 5, null);
+  set structValue(Struct v) {
+    setField(5, v);
+  }
+
+  bool hasStructValue() => $_has(4, 5);
+  void clearStructValue() => clearField(5);
+
+  ListValue get listValue => $_get(5, 6, null);
+  set listValue(ListValue v) {
+    setField(6, v);
+  }
+
+  bool hasListValue() => $_has(5, 6);
+  void clearListValue() => clearField(6);
+}
+
+class _ReadonlyValue extends Value with ReadonlyMessageMixin {}
+
+class ListValue extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('ListValue')
+    ..pp<Value>(1, 'values', PbFieldType.PM, Value.$checkItem, Value.create)
+    ..hasRequiredFields = false;
+
+  ListValue() : super();
+  ListValue.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  ListValue.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  ListValue clone() => new ListValue()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static ListValue create() => new ListValue();
+  static PbList<ListValue> createRepeated() => new PbList<ListValue>();
+  static ListValue getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyListValue();
+    return _defaultInstance;
+  }
+
+  static ListValue _defaultInstance;
+  static void $checkItem(ListValue v) {
+    if (v is! ListValue) checkItemFailed(v, 'ListValue');
+  }
+
+  List<Value> get values => $_get(0, 1, null);
+}
+
+class _ReadonlyListValue extends ListValue with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/protobuf/struct.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/struct.pbenum.dart
@@ -1,0 +1,25 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_struct_pbenum;
+
+// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
+import 'dart:core' show int, dynamic, String, List, Map;
+import 'package:protobuf/protobuf.dart';
+
+class NullValue extends ProtobufEnum {
+  static const NullValue NULL_VALUE = const NullValue._(0, 'NULL_VALUE');
+
+  static const List<NullValue> values = const <NullValue>[
+    NULL_VALUE,
+  ];
+
+  static final Map<int, dynamic> _byValue = ProtobufEnum.initByValue(values);
+  static NullValue valueOf(int value) => _byValue[value] as NullValue;
+  static void $checkItem(NullValue v) {
+    if (v is! NullValue) checkItemFailed(v, 'NullValue');
+  }
+
+  const NullValue._(int v, String n) : super(v, n);
+}

--- a/example/googleapis/lib/src/generated/google/protobuf/struct.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/struct.pbjson.dart
@@ -1,0 +1,117 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_struct_pbjson;
+
+const NullValue$json = const {
+  '1': 'NullValue',
+  '2': const [
+    const {'1': 'NULL_VALUE', '2': 0},
+  ],
+};
+
+const Struct$json = const {
+  '1': 'Struct',
+  '2': const [
+    const {
+      '1': 'fields',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Struct.FieldsEntry',
+      '10': 'fields'
+    },
+  ],
+  '3': const [Struct_FieldsEntry$json],
+};
+
+const Struct_FieldsEntry$json = const {
+  '1': 'FieldsEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {
+      '1': 'value',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Value',
+      '10': 'value'
+    },
+  ],
+  '7': const {'7': true},
+};
+
+const Value$json = const {
+  '1': 'Value',
+  '2': const [
+    const {
+      '1': 'null_value',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.google.protobuf.NullValue',
+      '9': 0,
+      '10': 'nullValue'
+    },
+    const {
+      '1': 'number_value',
+      '3': 2,
+      '4': 1,
+      '5': 1,
+      '9': 0,
+      '10': 'numberValue'
+    },
+    const {
+      '1': 'string_value',
+      '3': 3,
+      '4': 1,
+      '5': 9,
+      '9': 0,
+      '10': 'stringValue'
+    },
+    const {
+      '1': 'bool_value',
+      '3': 4,
+      '4': 1,
+      '5': 8,
+      '9': 0,
+      '10': 'boolValue'
+    },
+    const {
+      '1': 'struct_value',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '9': 0,
+      '10': 'structValue'
+    },
+    const {
+      '1': 'list_value',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.ListValue',
+      '9': 0,
+      '10': 'listValue'
+    },
+  ],
+  '8': const [
+    const {'1': 'kind'},
+  ],
+};
+
+const ListValue$json = const {
+  '1': 'ListValue',
+  '2': const [
+    const {
+      '1': 'values',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Value',
+      '10': 'values'
+    },
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/protobuf/timestamp.pb.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/timestamp.pb.dart
@@ -1,0 +1,56 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_timestamp;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:fixnum/fixnum.dart';
+import 'package:protobuf/protobuf.dart';
+
+class Timestamp extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Timestamp')
+    ..a<Int64>(1, 'seconds', PbFieldType.O6, Int64.ZERO)
+    ..a<int>(2, 'nanos', PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  Timestamp() : super();
+  Timestamp.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Timestamp.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Timestamp clone() => new Timestamp()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Timestamp create() => new Timestamp();
+  static PbList<Timestamp> createRepeated() => new PbList<Timestamp>();
+  static Timestamp getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyTimestamp();
+    return _defaultInstance;
+  }
+
+  static Timestamp _defaultInstance;
+  static void $checkItem(Timestamp v) {
+    if (v is! Timestamp) checkItemFailed(v, 'Timestamp');
+  }
+
+  Int64 get seconds => $_get(0, 1, null);
+  set seconds(Int64 v) {
+    $_setInt64(0, 1, v);
+  }
+
+  bool hasSeconds() => $_has(0, 1);
+  void clearSeconds() => clearField(1);
+
+  int get nanos => $_get(1, 2, 0);
+  set nanos(int v) {
+    $_setUnsignedInt32(1, 2, v);
+  }
+
+  bool hasNanos() => $_has(1, 2);
+  void clearNanos() => clearField(2);
+}
+
+class _ReadonlyTimestamp extends Timestamp with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/protobuf/timestamp.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/timestamp.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_timestamp_pbenum;

--- a/example/googleapis/lib/src/generated/google/protobuf/timestamp.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/protobuf/timestamp.pbjson.dart
@@ -1,0 +1,13 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.protobuf_timestamp_pbjson;
+
+const Timestamp$json = const {
+  '1': 'Timestamp',
+  '2': const [
+    const {'1': 'seconds', '3': 1, '4': 1, '5': 3, '10': 'seconds'},
+    const {'1': 'nanos', '3': 2, '4': 1, '5': 5, '10': 'nanos'},
+  ],
+};

--- a/example/googleapis/lib/src/generated/google/rpc/status.pb.dart
+++ b/example/googleapis/lib/src/generated/google/rpc/status.pb.dart
@@ -1,0 +1,61 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.rpc_status;
+
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:core' show int, bool, double, String, List, override;
+
+import 'package:protobuf/protobuf.dart';
+
+import '../protobuf/any.pb.dart' as $google$protobuf;
+
+class Status extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('Status')
+    ..a<int>(1, 'code', PbFieldType.O3)
+    ..a<String>(2, 'message', PbFieldType.OS)
+    ..pp<$google$protobuf.Any>(3, 'details', PbFieldType.PM,
+        $google$protobuf.Any.$checkItem, $google$protobuf.Any.create)
+    ..hasRequiredFields = false;
+
+  Status() : super();
+  Status.fromBuffer(List<int> i,
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromBuffer(i, r);
+  Status.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
+      : super.fromJson(i, r);
+  Status clone() => new Status()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static Status create() => new Status();
+  static PbList<Status> createRepeated() => new PbList<Status>();
+  static Status getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyStatus();
+    return _defaultInstance;
+  }
+
+  static Status _defaultInstance;
+  static void $checkItem(Status v) {
+    if (v is! Status) checkItemFailed(v, 'Status');
+  }
+
+  int get code => $_get(0, 1, 0);
+  set code(int v) {
+    $_setUnsignedInt32(0, 1, v);
+  }
+
+  bool hasCode() => $_has(0, 1);
+  void clearCode() => clearField(1);
+
+  String get message => $_get(1, 2, '');
+  set message(String v) {
+    $_setString(1, 2, v);
+  }
+
+  bool hasMessage() => $_has(1, 2);
+  void clearMessage() => clearField(2);
+
+  List<$google$protobuf.Any> get details => $_get(2, 3, null);
+}
+
+class _ReadonlyStatus extends Status with ReadonlyMessageMixin {}

--- a/example/googleapis/lib/src/generated/google/rpc/status.pbenum.dart
+++ b/example/googleapis/lib/src/generated/google/rpc/status.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.rpc_status_pbenum;

--- a/example/googleapis/lib/src/generated/google/rpc/status.pbjson.dart
+++ b/example/googleapis/lib/src/generated/google/rpc/status.pbjson.dart
@@ -1,0 +1,21 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library google.rpc_status_pbjson;
+
+const Status$json = const {
+  '1': 'Status',
+  '2': const [
+    const {'1': 'code', '3': 1, '4': 1, '5': 5, '10': 'code'},
+    const {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+    const {
+      '1': 'details',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'details'
+    },
+  ],
+};

--- a/example/googleapis/pubspec.yaml
+++ b/example/googleapis/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://github.com/dart-lang/grpc-dart
 
 environment:
-  sdk: '>=1.20.1 <2.0.0'
+  sdk: '>=1.24.3 <2.0.0'
 
 dependencies:
   async: ^1.13.3

--- a/example/googleapis/pubspec.yaml
+++ b/example/googleapis/pubspec.yaml
@@ -1,5 +1,5 @@
-name: interop
-description: Dart gRPC interoperability test suite.
+name: googleapis
+description: Dart gRPC client sample for Google APIs
 version: 0.0.1
 homepage: https://github.com/dart-lang/grpc-dart
 
@@ -7,11 +7,10 @@ environment:
   sdk: '>=1.20.1 <2.0.0'
 
 dependencies:
-  args: ^0.13.0
   async: ^1.13.3
-  collection: ^1.14.2
+  googleapis_auth: ^0.2.3+6
   grpc:
-    path: ../
+    path: ../../
   protobuf: ^0.6.0
 
 dev_dependencies:

--- a/example/googleapis/tool/regenerate.sh
+++ b/example/googleapis/tool/regenerate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [ ! -d "$PROTOBUF" ]; then
+  echo "Please set the PROTOBUF environment variable to your clone of google/protobuf."
+  exit -1
+fi
+
+if [ ! -d "$GOOGLEAPIS" ]; then
+  echo "Please set the GOOGLEAPIS environment variable to your clone of googleapis/googleapis."
+  exit -1
+fi
+
+PROTOC="protoc --dart_out=grpc:lib/src/generated -I$PROTOBUF/src -I$GOOGLEAPIS"
+
+$PROTOC $GOOGLEAPIS/google/logging/v2/logging.proto
+$PROTOC $GOOGLEAPIS/google/logging/v2/log_entry.proto
+$PROTOC $GOOGLEAPIS/google/logging/type/log_severity.proto
+$PROTOC $GOOGLEAPIS/google/logging/type/http_request.proto
+
+$PROTOC $GOOGLEAPIS/google/api/monitored_resource.proto
+$PROTOC $GOOGLEAPIS/google/api/label.proto
+
+$PROTOC $GOOGLEAPIS/google/rpc/status.proto
+
+$PROTOC $PROTOBUF/src/google/protobuf/any.proto
+$PROTOC $PROTOBUF/src/google/protobuf/duration.proto
+$PROTOC $PROTOBUF/src/google/protobuf/empty.proto
+$PROTOC $PROTOBUF/src/google/protobuf/struct.proto
+$PROTOC $PROTOBUF/src/google/protobuf/timestamp.proto
+
+dartfmt -w lib/src/generated

--- a/example/metadata/pubspec.yaml
+++ b/example/metadata/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://github.com/dart-lang/grpc-dart
 
 environment:
-  sdk: '>=1.20.1 <2.0.0'
+  sdk: '>=1.24.3 <2.0.0'
 
 dependencies:
   async: ^1.13.3

--- a/example/metadata/pubspec.yaml
+++ b/example/metadata/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   async: ^1.13.3
   grpc:
     path: ../../
-  protobuf: ^0.5.4
+  protobuf: ^0.6.0
 
 dev_dependencies:
   test: ^0.12.0

--- a/example/route_guide/README.md
+++ b/example/route_guide/README.md
@@ -29,7 +29,7 @@ $ dart bin/client.dart
 If you have made changes to the message or service definition in
 `protos/route_guide.proto` and need to regenerate the corresponding Dart files,
 you will need to have protoc version 3.0.0 or higher and the Dart protoc plugin
-version 0.7.7 or higher on your PATH.
+version 0.7.8 or higher on your PATH.
 
 To install protoc, see the instructions on
 [the Protocol Buffers website](https://developers.google.com/protocol-buffers/).

--- a/example/route_guide/lib/src/generated/route_guide.pb.dart
+++ b/example/route_guide/lib/src/generated/route_guide.pb.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library routeguide_route_guide;
 
 // ignore: UNUSED_SHOWN_NAME

--- a/example/route_guide/lib/src/generated/route_guide.pbenum.dart
+++ b/example/route_guide/lib/src/generated/route_guide.pbenum.dart
@@ -1,0 +1,5 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library routeguide_route_guide_pbenum;

--- a/example/route_guide/lib/src/generated/route_guide.pbgrpc.dart
+++ b/example/route_guide/lib/src/generated/route_guide.pbgrpc.dart
@@ -1,8 +1,7 @@
 ///
 //  Generated code. Do not modify.
 ///
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: library_prefixes
+// ignore_for_file: non_constant_identifier_names,library_prefixes
 library routeguide_route_guide_pbgrpc;
 
 import 'dart:async';

--- a/example/route_guide/lib/src/generated/route_guide.pbjson.dart
+++ b/example/route_guide/lib/src/generated/route_guide.pbjson.dart
@@ -1,0 +1,75 @@
+///
+//  Generated code. Do not modify.
+///
+// ignore_for_file: non_constant_identifier_names,library_prefixes
+library routeguide_route_guide_pbjson;
+
+const Point$json = const {
+  '1': 'Point',
+  '2': const [
+    const {'1': 'latitude', '3': 1, '4': 1, '5': 5, '10': 'latitude'},
+    const {'1': 'longitude', '3': 2, '4': 1, '5': 5, '10': 'longitude'},
+  ],
+};
+
+const Rectangle$json = const {
+  '1': 'Rectangle',
+  '2': const [
+    const {
+      '1': 'lo',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.routeguide.Point',
+      '10': 'lo'
+    },
+    const {
+      '1': 'hi',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.routeguide.Point',
+      '10': 'hi'
+    },
+  ],
+};
+
+const Feature$json = const {
+  '1': 'Feature',
+  '2': const [
+    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    const {
+      '1': 'location',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.routeguide.Point',
+      '10': 'location'
+    },
+  ],
+};
+
+const RouteNote$json = const {
+  '1': 'RouteNote',
+  '2': const [
+    const {
+      '1': 'location',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.routeguide.Point',
+      '10': 'location'
+    },
+    const {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+  ],
+};
+
+const RouteSummary$json = const {
+  '1': 'RouteSummary',
+  '2': const [
+    const {'1': 'point_count', '3': 1, '4': 1, '5': 5, '10': 'pointCount'},
+    const {'1': 'feature_count', '3': 2, '4': 1, '5': 5, '10': 'featureCount'},
+    const {'1': 'distance', '3': 3, '4': 1, '5': 5, '10': 'distance'},
+    const {'1': 'elapsed_time', '3': 4, '4': 1, '5': 5, '10': 'elapsedTime'},
+  ],
+};

--- a/example/route_guide/pubspec.yaml
+++ b/example/route_guide/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://github.com/dart-lang/grpc-dart
 
 environment:
-  sdk: '>=1.20.1 <2.0.0'
+  sdk: '>=1.24.3 <2.0.0'
 
 dependencies:
   async: ^1.13.3

--- a/example/route_guide/pubspec.yaml
+++ b/example/route_guide/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   async: ^1.13.3
   grpc:
     path: ../../
-  protobuf: ^0.5.4
+  protobuf: ^0.6.0
 
 dev_dependencies:
   test: ^0.12.0

--- a/interop/lib/src/generated/messages.pb.dart
+++ b/interop/lib/src/generated/messages.pb.dart
@@ -52,7 +52,7 @@ class _ReadonlyBoolValue extends BoolValue with ReadonlyMessageMixin {}
 class Payload extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('Payload')
     ..e<PayloadType>(1, 'type', PbFieldType.OE, PayloadType.COMPRESSABLE,
-        PayloadType.valueOf)
+        PayloadType.valueOf, PayloadType.values)
     ..a<List<int>>(2, 'body', PbFieldType.OY)
     ..hasRequiredFields = false;
 
@@ -143,7 +143,7 @@ class _ReadonlyEchoStatus extends EchoStatus with ReadonlyMessageMixin {}
 class SimpleRequest extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('SimpleRequest')
     ..e<PayloadType>(1, 'responseType', PbFieldType.OE,
-        PayloadType.COMPRESSABLE, PayloadType.valueOf)
+        PayloadType.COMPRESSABLE, PayloadType.valueOf, PayloadType.values)
     ..a<int>(2, 'responseSize', PbFieldType.O3)
     ..a<Payload>(
         3, 'payload', PbFieldType.OM, Payload.getDefault, Payload.create)
@@ -464,7 +464,7 @@ class _ReadonlyResponseParameters extends ResponseParameters
 class StreamingOutputCallRequest extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('StreamingOutputCallRequest')
     ..e<PayloadType>(1, 'responseType', PbFieldType.OE,
-        PayloadType.COMPRESSABLE, PayloadType.valueOf)
+        PayloadType.COMPRESSABLE, PayloadType.valueOf, PayloadType.values)
     ..pp<ResponseParameters>(2, 'responseParameters', PbFieldType.PM,
         ResponseParameters.$checkItem, ResponseParameters.create)
     ..a<Payload>(

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -87,7 +87,7 @@ class ChannelOptions {
         ..setTrustedCertificatesBytes(_certificateBytes,
             password: _certificatePassword);
     }
-    final context = SecurityContext.defaultContext;
+    final context = new SecurityContext(withTrustedRoots: true);
     if (SecurityContext.alpnSupported) {
       context.setAlpnProtocols(supportedAlpnProtocols, false);
     }
@@ -144,17 +144,16 @@ class ClientConnection {
 
   ConnectionState get state => _state;
 
-  static List<Header> createCallHeaders(
-      bool useTls, String authority, String path, CallOptions options) {
+  static List<Header> createCallHeaders(bool useTls, String authority,
+      String path, Duration timeout, Map<String, String> metadata) {
     final headers = [
       _methodPost,
       useTls ? _schemeHttps : _schemeHttp,
       new Header.ascii(':path', path),
       new Header.ascii(':authority', authority),
     ];
-    if (options.timeout != null) {
-      headers.add(
-          new Header.ascii('grpc-timeout', toTimeoutString(options.timeout)));
+    if (timeout != null) {
+      headers.add(new Header.ascii('grpc-timeout', toTimeoutString(timeout)));
     }
     headers.addAll([
       _contentTypeGrpc,
@@ -162,7 +161,7 @@ class ClientConnection {
       _grpcAcceptEncoding,
       _userAgent,
     ]);
-    options.metadata.forEach((key, value) {
+    metadata?.forEach((key, value) {
       headers.add(new Header.ascii(key, value));
     });
     return headers;
@@ -223,17 +222,21 @@ class ClientConnection {
     }
   }
 
+  ClientTransportStream makeRequest(
+      String path, Duration timeout, Map<String, String> metadata) {
+    final headers =
+        createCallHeaders(options.isSecure, authority, path, timeout, metadata);
+    return _transport.makeRequest(headers);
+  }
+
   void _startCall(ClientCall call) {
     if (call._isCancelled) return;
-    final headers =
-        createCallHeaders(options.isSecure, authority, call.path, call.options);
-    final stream = _transport.makeRequest(headers);
-    call._onConnectedStream(stream);
+    call._onConnectionReady(this);
   }
 
   void _shutdownCall(ClientCall call) {
     if (call._isCancelled) return;
-    call._onConnectError(
+    call._onConnectionError(
         new GrpcError.unavailable('Connection shutting down.'));
   }
 
@@ -382,7 +385,7 @@ class ClientChannel {
     getConnection().then((connection) {
       if (call._isCancelled) return;
       connection.dispatchCall(call);
-    }, onError: call._onConnectError);
+    }, onError: call._onConnectionError);
     return call;
   }
 }
@@ -396,31 +399,40 @@ class ClientMethod<Q, R> {
   ClientMethod(this.path, this.requestSerializer, this.responseDeserializer);
 }
 
+/// Provides per-RPC metadata.
+///
+/// Metadata providers will be invoked for every RPC, and can add their own
+/// metadata to the RPC. If the function returns a [Future], the RPC will await
+/// completion of the returned [Future] before transmitting the request.
+typedef FutureOr<Null> MetadataProvider(Map<String, String> metadata);
+
 /// Runtime options for an RPC.
 class CallOptions {
   final Map<String, String> metadata;
   final Duration timeout;
+  final List<MetadataProvider> metadataProviders;
 
-  CallOptions._(this.metadata, this.timeout);
+  CallOptions._(this.metadata, this.timeout, this.metadataProviders);
 
-  factory CallOptions({Map<String, String> metadata, Duration timeout}) {
-    final sanitizedMetadata = <String, String>{};
-    metadata?.forEach((key, value) {
-      final lowerCaseKey = key.toLowerCase();
-      if (!lowerCaseKey.startsWith(':') &&
-          !_reservedHeaders.contains(lowerCaseKey)) {
-        sanitizedMetadata[lowerCaseKey] = value;
-      }
-    });
-    return new CallOptions._(new Map.unmodifiable(sanitizedMetadata), timeout);
+  factory CallOptions(
+      {Map<String, String> metadata,
+      Duration timeout,
+      List<MetadataProvider> providers}) {
+    return new CallOptions._(new Map.unmodifiable(metadata ?? {}), timeout,
+        new List.unmodifiable(providers ?? []));
   }
+
+  factory CallOptions.from(Iterable<CallOptions> options) =>
+      options.fold(new CallOptions(), (p, o) => p.mergedWith(o));
 
   CallOptions mergedWith(CallOptions other) {
     if (other == null) return this;
     final mergedMetadata = new Map.from(metadata)..addAll(other.metadata);
     final mergedTimeout = other.timeout ?? timeout;
-    return new CallOptions._(
-        new Map.unmodifiable(mergedMetadata), mergedTimeout);
+    final mergedProviders = new List.from(metadataProviders)
+      ..addAll(other.metadataProviders);
+    return new CallOptions._(new Map.unmodifiable(mergedMetadata),
+        mergedTimeout, new List.unmodifiable(mergedProviders));
   }
 }
 
@@ -468,21 +480,49 @@ class ClientCall<Q, R> implements Response {
 
   String get path => _method.path;
 
-  void _onConnectError(error) {
+  void _onConnectionError(error) {
+    _terminateWithError(new GrpcError.unavailable('Error connecting: $error'));
+  }
+
+  void _terminateWithError(GrpcError error) {
     if (!_responses.isClosed) {
-      _responses
-          .addError(new GrpcError.unavailable('Error connecting: $error'));
+      _responses.addError(error);
     }
     _safeTerminate();
   }
 
-  void _onConnectedStream(ClientTransportStream stream) {
-    if (_isCancelled) {
-      // Should not happen, but just in case.
-      stream.terminate();
-      return;
+  static Map<String, String> _sanitizeMetadata(Map<String, String> metadata) {
+    final sanitizedMetadata = <String, String>{};
+    metadata.forEach((String key, String value) {
+      final lowerCaseKey = key.toLowerCase();
+      if (!lowerCaseKey.startsWith(':') &&
+          !_reservedHeaders.contains(lowerCaseKey)) {
+        sanitizedMetadata[lowerCaseKey] = value;
+      }
+    });
+    return sanitizedMetadata;
+  }
+
+  void _onConnectionReady(ClientConnection connection) {
+    if (_isCancelled) return;
+
+    if (options.metadataProviders.isEmpty) {
+      _sendRequest(connection, _sanitizeMetadata(options.metadata));
+    } else {
+      final metadata = new Map.from(options.metadata);
+      Future
+          .forEach(options.metadataProviders, (provider) => provider(metadata))
+          .then((_) => _sendRequest(connection, _sanitizeMetadata(metadata)))
+          .catchError(_onMetadataProviderError);
     }
-    _stream = stream;
+  }
+
+  void _onMetadataProviderError(error) {
+    _terminateWithError(new GrpcError.internal('Error making call: $error'));
+  }
+
+  void _sendRequest(ClientConnection connection, Map<String, String> metadata) {
+    _stream = connection.makeRequest(path, options.timeout, metadata);
     _requestSubscription = _requests
         .map(_method.requestSerializer)
         .map(GrpcHttpEncoder.frame)

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -404,6 +404,10 @@ class ClientMethod<Q, R> {
 /// Metadata providers will be invoked for every RPC, and can add their own
 /// metadata to the RPC. If the function returns a [Future], the RPC will await
 /// completion of the returned [Future] before transmitting the request.
+///
+/// The metadata provider is given the current metadata map (possibly modified
+/// by previous metadata providers), and is expected to modify the map before
+/// returning or before completing the returned [Future].
 typedef FutureOr<Null> MetadataProvider(Map<String, String> metadata);
 
 /// Runtime options for an RPC.
@@ -414,6 +418,12 @@ class CallOptions {
 
   CallOptions._(this.metadata, this.timeout, this.metadataProviders);
 
+  /// Creates a [CallOptions] object.
+  ///
+  /// [CallOptions] can specify static [metadata], set the [timeout], and
+  /// configure per-RPC metadata [providers]. The metadata [providers] are
+  /// invoked in order for every RPC, and can modify the outgoing metadata
+  /// (including metadata provided by previous providers).
   factory CallOptions(
       {Map<String, String> metadata,
       Duration timeout,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart
 
 environment:
-  sdk: '>=1.20.1 <2.0.0'
+  sdk: '>=1.24.3 <2.0.0'
 
 dependencies:
   async: ^1.13.3

--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -32,10 +32,10 @@ class TestService extends Service {
         'ServerStreaming', _serverStreaming, false, true));
     $addMethod(ServerHarness.createMethod(
         'Bidirectional', _bidirectional, true, true));
-    $addMethod(new ServiceMethod('RequestError', _bidirectional, true, true,
-        (List<int> value) => throw 'Failed', mockEncode));
-    $addMethod(new ServiceMethod('ResponseError', _bidirectional, true, true,
-        mockDecode, (int value) => throw 'Failed'));
+    $addMethod(new ServiceMethod<int, int>('RequestError', _bidirectional, true,
+        true, (List<int> value) => throw 'Failed', mockEncode));
+    $addMethod(new ServiceMethod<int, int>('ResponseError', _bidirectional,
+        true, true, mockDecode, (int value) => throw 'Failed'));
   }
 
   Future<int> _unary(ServiceCall call, Future<int> request) {
@@ -145,9 +145,8 @@ class ServerHarness {
       {String authority = 'test',
       Map<String, String> metadata,
       Duration timeout}) {
-    final options = new CallOptions(metadata: metadata, timeout: timeout);
-    final headers =
-        ClientConnection.createCallHeaders(true, authority, path, options);
+    final headers = ClientConnection.createCallHeaders(
+        true, authority, path, timeout, metadata);
     toServer.add(new HeadersStreamMessage(headers));
   }
 


### PR DESCRIPTION
Provide a hook for metadata providers that need to generate their
metadata for each RPC. An example is authorization, where the provider
may need to refresh a token before it can provide the header.

Add stackdriver logging examplei to demonstrate calling a Google API.

Updated other examples to protobuf 0.6.0 (protoc plugin 0.7.8).

Review note: All the \*.pb\*.dart files (example/googleapis/lib/src/generated/*, etc.) are generated from .proto source. Unless you're feeling really diligent, there's no need to review them.