### PR TITLE
Use thenAnswer() instead of thenReturn() when returning a Stream.

### DIFF
--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -118,7 +118,7 @@ class ClientHarness {
     when(transport.makeRequest(any)).thenReturn(stream);
     when(transport.onActiveStateChanged = captureAny).thenReturn(null);
     when(stream.outgoingMessages).thenReturn(fromClient.sink);
-    when(stream.incomingMessages).thenReturn(toClient.stream);
+    when(stream.incomingMessages).thenAnswer((_) => toClient.stream);
     client = new TestClient(channel);
   }
 


### PR DESCRIPTION
Mockito will soon start throwing an ArgumentError if thenReturn()
is called with a Future or Stream, as this can result in difficult
to trace errors.