### PR TITLE
Fix bad override in test.

### DIFF
--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -94,7 +94,7 @@ class TestServerStream extends ServerTransportStream {
   }
 
   @override
-  set onTerminated(void value(int)) {}
+  set onTerminated(void value(int x)) {}
 
   @override
   bool get canPush => true;


### PR DESCRIPTION
This override was just missing a variable name, hence the type was misinterpreted as the variable name.